### PR TITLE
Metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+## Project
+
+kueue is a persistent message queue server written in Go. Single binary, no dependencies beyond BadgerDB and uuid. Stdlib `net/http` for the server — no framework.
+
+## Commands
+
+```bash
+go test ./...          # run all tests (always run after changes)
+go build ./...          # verify compilation
+go run main.go          # run the server (PORT=8080, KUEUE_DB_PATH=./tmp/badger)
+go run ./cmd/bench      # run benchmarks against kueue and/or rabbitmq
+```
+
+## Architecture
+
+Everything lives in `main.go`. There is no package splitting.
+
+### Data model
+
+- **Queue**: stored in BadgerDB as key=`<uuid>`, value=`QueueConfig{Name, MaxRetries}`. The ID is the key clients pass around.
+- **Message**: stored as key=`<queueID>|<8-byte-big-endian-seq>|<messageID>`, value=JSON `Message`. The sequence number gives FIFO ordering. State machine: `ready -> in_flight -> ready|dead`.
+
+### Key design decisions
+
+- **FIFO ordering**: `messageKey` uses `GetSequence` for monotonically increasing keys. Badger iterators return lexicographic order, so `claimNextReadyMessage` scans in enqueue order.
+- **Atomic claim**: `claimNextReadyMessage` runs inside a single `Db.Update` transaction. It finds the first `StateReady` message, flips it to `StateInFlight`, and writes it back — all atomically. This is what makes competing consumers safe.
+- **Visibility timeout**: 30 seconds hardcoded. The reaper goroutine (`reaper()`) runs every 1 second, calls `reapExpiredMessages` which scans ALL keys (not per-queue), finds in-flight messages past their `VisibilityDeadline`, and transitions them.
+- **Delivery tokens**: Each claim generates a `DeliveryAttemptID` (UUID). Both `/ack` and `/nack` require this token. If a message is re-delivered (after timeout expiry), the old token is rejected with 409. This prevents stale acks.
+- **Long polling**: `signalQueueReady` closes the old per-queue channel and creates a new one. `receive?wait=true` blocks on that channel with a 30s timeout. The re-check between subscribing and waiting prevents lost signals.
+- **Dead letter**: When `DeliveryCount >= MaxDeliveryCount` and the message is nacked or reaped, state becomes `dead`. Dead messages stay in the store but are never returned by receive.
+
+### Metrics
+
+Per-queue in-memory counters in `queueMetrics`, stored in a `sync.Map` (`metricsStore`). On `/metrics?id=X`, `reconcileMetricsFromDB` scans BadgerDB for truth and uses `snapshotMax` (CAS loop) to avoid overwriting live counters with stale snapshots.
+
+`ackWindow` is a sliding window of ack timestamps (60s). `trimAckWindow` is called from the reaper goroutine every second to prevent unbounded growth — not just from `/metrics`.
+
+### Reaper returns transitions
+
+`reapExpiredMessages` returns `[]reapTransition{QueueID, ToState}`. The reaper goroutine updates per-queue metrics per transition and only calls `signalQueueReady` when `ToState == StateReady` — dead-letter transitions must not wake long-polling consumers.
+
+## Testing
+
+Tests in `main_test.go` use `httptest.NewRecorder` + direct handler calls against a temp BadgerDB. No HTTP server startup. Pattern: `setupTestDB(t)` opens BadgerDB in `t.TempDir()` and resets global state including `metricsStore`. Tests do NOT test the reaper goroutine directly — they call `reapExpiredMessages` synchronously.
+
+When adding new global state (like `metricsStore`), add cleanup in `setupTestDB`.
+
+## Known gotchas
+
+- `var queue []int` (line 19) and `var Queues []Queue` / `var DeadLetterQueue []Message` (lines 63-64) are legacy in-memory remnants. They should not be used.
+- `reapExpiredMessages` scans ALL keys with no prefix filter — it iterates the entire DB. This is intentional because it needs to find expired in-flight messages across all queues in one pass.
+- BadgerDB `item.Key()` is only valid inside the `item.Value()` callback. Always use `item.KeyCopy(nil)` if you need the key outside that callback.
+- The `Db` package global is set in `main()` and used everywhere. Tests set it in `setupTestDB`.
+- The `getQueue` handler does not return after writing the empty-id error — it falls through to the DB query with an empty string. This is a known bug, not a feature.

--- a/main.go
+++ b/main.go
@@ -752,8 +752,6 @@ type reapTransition struct {
 }
 
 func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
-	recoveredQueues := map[string]struct{}{}
-
 	transitions := []reapTransition{}
 
 	err := Db.Update(func(txn *badger.Txn) error {
@@ -799,7 +797,6 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 					return err
 				}
 
-				recoveredQueues[queueID] = struct{}{}
 				transitions = append(transitions, reapTransition{QueueID: queueID, ToState: msg.State})
 				return nil
 			})

--- a/main.go
+++ b/main.go
@@ -706,8 +706,15 @@ func nack(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func reapExpiredMessages(now time.Time) ([]string, error) {
+type reapTransition struct {
+	QueueID string
+	ToState MessageState
+}
+
+func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 	recoveredQueues := map[string]struct{}{}
+
+	transitions := []reapTransition{}
 
 	err := Db.Update(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
@@ -753,6 +760,7 @@ func reapExpiredMessages(now time.Time) ([]string, error) {
 				}
 
 				recoveredQueues[queueID] = struct{}{}
+				transitions = append(transitions, reapTransition{QueueID: queueID, ToState: msg.State})
 				return nil
 			})
 			if err != nil {
@@ -763,12 +771,7 @@ func reapExpiredMessages(now time.Time) ([]string, error) {
 		return nil
 	})
 
-	queueIDs := make([]string, 0, len(recoveredQueues))
-	for queueID := range recoveredQueues {
-		queueIDs = append(queueIDs, queueID)
-	}
-
-	return queueIDs, err
+	return transitions, err
 }
 
 // runs every second and resets expired in-flight messages back to ready in Badger.
@@ -779,14 +782,25 @@ func reaper() {
 		defer ticker.Stop()
 
 		for range ticker.C {
-			recoveredQueueIDs, err := reapExpiredMessages(time.Now())
+			transitions, err := reapExpiredMessages(time.Now())
 			if err != nil {
 				log.Println("reaper:", err)
 				continue
 			}
 
-			for _, queueID := range recoveredQueueIDs {
-				signalQueueReady(queueID)
+			signaled := map[string]struct{}{}
+			for _, t := range transitions {
+				m := getOrCreateMetrics(t.QueueID)
+				m.inFlightCount.Add(-1)
+				if t.ToState == StateReady {
+					m.readyCount.Add(1)
+				} else if t.ToState == StateDead {
+					m.deadCount.Add(1)
+				}
+				if _, ok := signaled[t.QueueID]; !ok {
+					signalQueueReady(t.QueueID)
+					signaled[t.QueueID] = struct{}{}
+				}
 			}
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func getOrCreateMetrics(queueID string) *queueMetrics {
 	return actual.(*queueMetrics)
 }
 
-func reconcileMetricsFromDB(queueID string, m *queueMetrics) {
+func reconcileMetricsFromDB(queueID string, m *queueMetrics) error {
 	var ready, inFlight, dead int64
 	err := Db.View(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
@@ -127,7 +127,7 @@ func reconcileMetricsFromDB(queueID string, m *queueMetrics) {
 		defer it.Close()
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
-			err := item.Value(func(v []byte) error {
+			if err := item.Value(func(v []byte) error {
 				var msg Message
 				if err := json.Unmarshal(v, &msg); err != nil {
 					return err
@@ -141,19 +141,20 @@ func reconcileMetricsFromDB(queueID string, m *queueMetrics) {
 					dead++
 				}
 				return nil
-			})
-			if err != nil {
+			}); err != nil {
+				log.Printf("reconcileMetricsFromDB: error reading message in queue %s: %v", queueID, err)
 				return err
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return
+		return err
 	}
 	m.readyCount.Store(ready)
 	m.inFlightCount.Store(inFlight)
 	m.deadCount.Store(dead)
+	return nil
 }
 
 // channel for long polling in receive
@@ -865,7 +866,10 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	m := getOrCreateMetrics(id)
-	reconcileMetricsFromDB(id, m)
+	if err := reconcileMetricsFromDB(id, m); err != nil {
+		http.Error(w, "Error reconciling metrics: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 	m.trimAckWindow()
 
 	w.Header().Set("Content-Type", "application/json")

--- a/main.go
+++ b/main.go
@@ -695,6 +695,15 @@ func nack(w http.ResponseWriter, r *http.Request) {
 		"state":   nackResultState,
 	})
 
+	m := getOrCreateMetrics(ackReq.QueueId)
+	m.totalNacked.Add(1)
+	m.inFlightCount.Add(-1)
+	if nackResultState == StateReady {
+		m.readyCount.Add(1)
+	} else if nackResultState == StateDead {
+		m.deadCount.Add(1)
+	}
+
 }
 
 func reapExpiredMessages(now time.Time) ([]string, error) {

--- a/main.go
+++ b/main.go
@@ -78,6 +78,34 @@ type queueMetrics struct {
 
 var metricsStore sync.Map
 
+func (m *queueMetrics) recordAck() {
+	m.totalAcked.Add(1)
+	m.inFlightCount.Add(-1)
+	m.ackMu.Lock()
+	m.ackWindow = append(m.ackWindow, time.Now())
+	m.ackMu.Unlock()
+}
+
+func (m *queueMetrics) trimAckWindow() {
+	m.ackMu.Lock()
+	defer m.ackMu.Unlock()
+	windowStart := time.Now().Add(-60 * time.Second)
+	i := 0
+	for i < len(m.ackWindow) && m.ackWindow[i].Before(windowStart) {
+		i++
+	}
+	m.ackWindow = m.ackWindow[i:]
+}
+
+func (m *queueMetrics) ackRatePerSec() float64 {
+	m.ackMu.Lock()
+	defer m.ackMu.Unlock()
+	if len(m.ackWindow) == 0 {
+		return 0
+	}
+	return float64(len(m.ackWindow)) / 60.0
+}
+
 func getOrCreateMetrics(queueID string) *queueMetrics {
 	if m, ok := metricsStore.Load(queueID); ok {
 		return m.(*queueMetrics)
@@ -614,11 +642,7 @@ func ack(w http.ResponseWriter, r *http.Request) {
 	})
 
 	m := getOrCreateMetrics(ackReq.QueueId)
-	m.totalAcked.Add(1)
-	m.inFlightCount.Add(-1)
-	m.ackMu.Lock()
-	m.ackWindow = append(m.ackWindow, time.Now())
-	m.ackMu.Unlock()
+	m.recordAck()
 
 }
 
@@ -805,6 +829,11 @@ func reaper() {
 					signaled[t.QueueID] = struct{}{}
 				}
 			}
+
+			metricsStore.Range(func(_, value any) bool {
+				value.(*queueMetrics).trimAckWindow()
+				return true
+			})
 		}
 	}()
 
@@ -837,22 +866,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 
 	m := getOrCreateMetrics(id)
 	reconcileMetricsFromDB(id, m)
-
-	m.ackMu.Lock()
-	now := time.Now()
-	windowStart := now.Add(-60 * time.Second)
-	i := 0
-	for i < len(m.ackWindow) && m.ackWindow[i].Before(windowStart) {
-		i++
-	}
-	m.ackWindow = m.ackWindow[i:]
-	windowLen := len(m.ackWindow)
-	m.ackMu.Unlock()
-
-	var ackRatePerSec float64
-	if windowLen > 0 {
-		ackRatePerSec = float64(windowLen) / 60.0
-	}
+	m.trimAckWindow()
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -865,8 +879,8 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 		"totalReceived":  m.totalReceived.Load(),
 		"totalAcked":     m.totalAcked.Load(),
 		"totalNacked":    m.totalNacked.Load(),
-		"ackRatePerSec":  ackRatePerSec,
-		"uptimeSeconds":  now.Sub(m.startedAt).Seconds(),
+		"ackRatePerSec":  m.ackRatePerSec(),
+		"uptimeSeconds":  time.Now().Sub(m.startedAt).Seconds(),
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -613,6 +613,10 @@ func ack(w http.ResponseWriter, r *http.Request) {
 		"message": "Message Acknowledged and removed from queue",
 	})
 
+	m := getOrCreateMetrics(ackReq.QueueId)
+	m.totalAcked.Add(1)
+	m.inFlightCount.Add(-1)
+
 }
 
 func nack(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -616,6 +616,9 @@ func ack(w http.ResponseWriter, r *http.Request) {
 	m := getOrCreateMetrics(ackReq.QueueId)
 	m.totalAcked.Add(1)
 	m.inFlightCount.Add(-1)
+	m.ackMu.Lock()
+	m.ackWindow = append(m.ackWindow, time.Now())
+	m.ackMu.Unlock()
 
 }
 
@@ -807,6 +810,66 @@ func reaper() {
 
 }
 
+func metricsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Only GET allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	params := r.URL.Query()
+	id := params.Get("id")
+	if id == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	err := Db.View(func(txn *badger.Txn) error {
+		_, err := txn.Get([]byte(id))
+		return err
+	})
+	if err != nil {
+		if err == badger.ErrKeyNotFound {
+			http.Error(w, "Queue Not Found for id: "+id, http.StatusNotFound)
+			return
+		}
+		http.Error(w, "Error checking queue: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	m := getOrCreateMetrics(id)
+	reconcileMetricsFromDB(id, m)
+
+	m.ackMu.Lock()
+	now := time.Now()
+	windowStart := now.Add(-60 * time.Second)
+	i := 0
+	for i < len(m.ackWindow) && m.ackWindow[i].Before(windowStart) {
+		i++
+	}
+	m.ackWindow = m.ackWindow[i:]
+	windowLen := len(m.ackWindow)
+	m.ackMu.Unlock()
+
+	var ackRatePerSec float64
+	if windowLen > 0 {
+		ackRatePerSec = float64(windowLen) / 60.0
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]any{
+		"queueId":        id,
+		"readyCount":     m.readyCount.Load(),
+		"inFlightCount":  m.inFlightCount.Load(),
+		"deadCount":      m.deadCount.Load(),
+		"totalPublished": m.totalPublished.Load(),
+		"totalReceived":  m.totalReceived.Load(),
+		"totalAcked":     m.totalAcked.Load(),
+		"totalNacked":    m.totalNacked.Load(),
+		"ackRatePerSec":  ackRatePerSec,
+		"uptimeSeconds":  now.Sub(m.startedAt).Seconds(),
+	})
+}
+
 func main() {
 	dbPath := os.Getenv("KUEUE_DB_PATH")
 	if dbPath == "" {
@@ -833,6 +896,7 @@ func main() {
 	http.HandleFunc("/ack", ack)
 	http.HandleFunc("/nack", nack)
 	http.HandleFunc("/receive", receive)
+	http.HandleFunc("/metrics", metricsHandler)
 
 	reaper()
 	fmt.Println("Producer Running on Port " + port)

--- a/main.go
+++ b/main.go
@@ -78,6 +78,56 @@ type queueMetrics struct {
 
 var metricsStore sync.Map
 
+func getOrCreateMetrics(queueID string) *queueMetrics {
+	if m, ok := metricsStore.Load(queueID); ok {
+		return m.(*queueMetrics)
+	}
+	m := &queueMetrics{
+		startedAt: time.Now(),
+	}
+	actual, _ := metricsStore.LoadOrStore(queueID, m)
+	return actual.(*queueMetrics)
+}
+
+func reconcileMetricsFromDB(queueID string, m *queueMetrics) {
+	var ready, inFlight, dead int64
+	err := Db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = true
+		opts.Prefix = queueMessagePrefix(queueID)
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			item := it.Item()
+			err := item.Value(func(v []byte) error {
+				var msg Message
+				if err := json.Unmarshal(v, &msg); err != nil {
+					return err
+				}
+				switch msg.State {
+				case StateReady:
+					ready++
+				case StateInFlight:
+					inFlight++
+				case StateDead:
+					dead++
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return
+	}
+	m.readyCount.Store(ready)
+	m.inFlightCount.Store(inFlight)
+	m.deadCount.Store(dead)
+}
+
 // channel for long polling in receive
 var receiveChannel = make(chan struct{}, 1)
 var queueReadyChans = map[string]chan struct{}{}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dgraph-io/badger/v4"
@@ -61,6 +62,21 @@ var Db *badger.DB
 
 var Queues []Queue
 var DeadLetterQueue []Message
+
+type queueMetrics struct {
+	readyCount     atomic.Int64
+	inFlightCount  atomic.Int64
+	deadCount      atomic.Int64
+	totalPublished atomic.Int64
+	totalReceived  atomic.Int64
+	totalAcked     atomic.Int64
+	totalNacked    atomic.Int64
+	ackWindow      []time.Time
+	ackMu          sync.Mutex
+	startedAt      time.Time
+}
+
+var metricsStore sync.Map
 
 // channel for long polling in receive
 var receiveChannel = make(chan struct{}, 1)

--- a/main.go
+++ b/main.go
@@ -822,12 +822,12 @@ func reaper() {
 				m.inFlightCount.Add(-1)
 				if t.ToState == StateReady {
 					m.readyCount.Add(1)
+					if _, ok := signaled[t.QueueID]; !ok {
+						signalQueueReady(t.QueueID)
+						signaled[t.QueueID] = struct{}{}
+					}
 				} else if t.ToState == StateDead {
 					m.deadCount.Add(1)
-				}
-				if _, ok := signaled[t.QueueID]; !ok {
-					signalQueueReady(t.QueueID)
-					signaled[t.QueueID] = struct{}{}
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -407,6 +407,10 @@ func publish(w http.ResponseWriter, r *http.Request) {
 
 	signalQueueReady(queueId)
 
+	m := getOrCreateMetrics(queueId)
+	m.totalPublished.Add(1)
+	m.readyCount.Add(1)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(map[string]any{
@@ -536,6 +540,11 @@ func receive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
 		return
 	}
+
+	m := getOrCreateMetrics(id)
+	m.totalReceived.Add(1)
+	m.readyCount.Add(-1)
+	m.inFlightCount.Add(1)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)

--- a/main.go
+++ b/main.go
@@ -78,6 +78,18 @@ type queueMetrics struct {
 
 var metricsStore sync.Map
 
+func snapshotMax(counter *atomic.Int64, val int64) {
+	for {
+		cur := counter.Load()
+		if cur >= val {
+			return
+		}
+		if counter.CompareAndSwap(cur, val) {
+			return
+		}
+	}
+}
+
 func (m *queueMetrics) recordAck() {
 	m.totalAcked.Add(1)
 	m.inFlightCount.Add(-1)
@@ -151,9 +163,9 @@ func reconcileMetricsFromDB(queueID string, m *queueMetrics) error {
 	if err != nil {
 		return err
 	}
-	m.readyCount.Store(ready)
-	m.inFlightCount.Store(inFlight)
-	m.deadCount.Store(dead)
+	snapshotMax(&m.readyCount, ready)
+	snapshotMax(&m.inFlightCount, inFlight)
+	snapshotMax(&m.deadCount, dead)
 	return nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ func setupTestDB(t *testing.T) {
 	DeadLetterQueue = nil
 	receiveChannel = make(chan struct{}, 1)
 	queueReadyChans = map[string]chan struct{}{}
+	metricsStore = sync.Map{}
 
 	t.Cleanup(func() {
 		_ = db.Close()
@@ -397,11 +399,11 @@ func TestReapExpiredMessagesResetsPersistedInFlightMessage(t *testing.T) {
 		t.Fatalf("prepare expired in-flight message: %v", err)
 	}
 
-	recoveredQueueIDs, err := reapExpiredMessages(time.Now())
+	recoveredTransitions, err := reapExpiredMessages(time.Now())
 	if err != nil {
 		t.Fatalf("reap expired messages: %v", err)
 	}
-	if len(recoveredQueueIDs) != 1 || recoveredQueueIDs[0] != queueID {
+	if len(recoveredTransitions) != 1 || recoveredTransitions[0].QueueID != queueID {
 		t.Fatal("expected reapExpiredMessages to recover the expired message")
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/metrics` endpoint returning per-queue realtime stats: 60s ack rate, totals (published/received/acked/nacked), and current ready/in-flight/dead counts.
  * Introduced in-memory per-queue metrics with periodic reconciliation from storage for accurate reporting.

* **Bug Fixes**
  * Improved metric accuracy by updating counts on message state transitions and trimming the rolling ack window.

* **Tests**
  * Updated tests to initialize the metrics store and validate transition-based recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->