### PR TITLE
Ready index

### DIFF
--- a/main.go
+++ b/main.go
@@ -655,20 +655,24 @@ func receive(w http.ResponseWriter, r *http.Request) {
 		}
 		if claimErr == ErrNoReadyMessages {
 			readyCh := queueReadyChan(id)
-
-			msg, claimErr = claimNextReadyMessage(id)
-			if claimErr != nil && claimErr != ErrNoReadyMessages {
-				http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
-				return
-			}
-			if claimErr == ErrNoReadyMessages {
-				timer := time.NewTimer(30 * time.Second)
-				defer timer.Stop()
+			timer := time.NewTimer(30 * time.Second)
+			defer timer.Stop()
+		waitLoop:
+			for {
+				msg, claimErr = claimNextReadyMessage(id)
+				if claimErr == nil {
+					break
+				}
+				if claimErr != nil && claimErr != ErrNoReadyMessages {
+					http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
+					return
+				}
 				select {
 				case <-readyCh:
-					msg, claimErr = claimNextReadyMessage(id)
+					readyCh = queueReadyChan(id)
+					continue
 				case <-timer.C:
-					// timed out — fall through with msg == nil
+					break waitLoop
 				case <-r.Context().Done():
 					return
 				}

--- a/main.go
+++ b/main.go
@@ -471,7 +471,10 @@ func publish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = Db.Update(func(txn *badger.Txn) error {
-		return txn.Set(messageKey(queueId, seq, message.Message.ID), messageJson)
+		if err := txn.Set(messageKey(queueId, seq, message.Message.ID), messageJson); err != nil {
+			return err
+		}
+		return txn.Set(readyKey(queueId, seq, message.Message.ID), []byte{})
 	})
 	if err != nil {
 		http.Error(w, "Error Saving Message: "+err.Error(), http.StatusInternalServerError)
@@ -797,6 +800,9 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
 			key := item.KeyCopy(nil)
+			if bytes.HasPrefix(key, []byte("ready|")) || bytes.HasPrefix(key, []byte("seq:")) {
+				continue
+			}
 			pipeIndex := bytes.IndexByte(key, '|')
 			if pipeIndex == -1 {
 				continue

--- a/main.go
+++ b/main.go
@@ -241,14 +241,16 @@ func parseReadyValue(val []byte) (uint64, error) {
 }
 
 func parseMessageKeySeq(key []byte) (uint64, error) {
-	parts := bytes.SplitN(key, []byte("|"), 3)
-	if len(parts) < 2 {
-		return 0, fmt.Errorf("invalid message key format")
+	idx := bytes.IndexByte(key, '|')
+	if idx == -1 {
+		return 0, fmt.Errorf("invalid message key format: no delimiter")
 	}
-	if len(parts[1]) != 8 {
-		return 0, fmt.Errorf("invalid seq in message key")
+	seqStart := idx + 1
+	seqEnd := seqStart + 8
+	if seqEnd > len(key) {
+		return 0, fmt.Errorf("invalid message key format: seq too short")
 	}
-	return binary.BigEndian.Uint64(parts[1]), nil
+	return binary.BigEndian.Uint64(key[seqStart:seqEnd]), nil
 }
 
 func parseReadyKey(key []byte) (seq uint64, messageID string, err error) {

--- a/main.go
+++ b/main.go
@@ -498,54 +498,78 @@ func publish(w http.ResponseWriter, r *http.Request) {
 
 }
 
-// claimNextReadyMessage scans all messages for a queue (prefix queueId|),
-// finds the first one in StateReady, atomically updates it to StateInFlight
-// in the same Db.Update transaction, and returns it.
+// claimNextReadyMessage seeks the first ready pointer for the queue,
+// reads the corresponding message, atomically transitions it to StateInFlight,
+// and deletes the ready pointer — all in a single Db.Update transaction.
+// Returns ErrNoReadyMessages if no ready messages are available.
 func claimNextReadyMessage(queueId string) (*Message, error) {
 	var claimed *Message
 	err := Db.Update(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
-		opts.PrefetchValues = true
-		opts.Prefix = queueMessagePrefix(queueId)
+		opts.PrefetchValues = false
+		opts.Prefix = readyPrefix(queueId)
 		it := txn.NewIterator(opts)
 		defer it.Close()
 
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
-			err := item.Value(func(v []byte) error {
-				var msg Message
-				if err := json.Unmarshal(v, &msg); err != nil {
-					return err
-				}
-				if msg.State != StateReady {
-					return nil // skip non-ready messages
-				}
-				// claim: flip to in-flight
-				msg.State = StateInFlight
-				msg.VisibilityDeadline = time.Now().Add(30 * time.Second)
-				msg.DeliveryCount++
-				msg.DeliveryAttemptID = uuid.NewString()
-				updated, err := json.Marshal(msg)
-				if err != nil {
-					return err
-				}
-				// must copy the key — item.Key() is only valid inside this callback
-				if err := txn.Set(item.KeyCopy(nil), updated); err != nil {
-					return err
-				}
-				claimed = &msg
-				return nil
-			})
+			rKey := item.KeyCopy(nil)
+			seq, msgID, err := parseReadyKey(rKey)
 			if err != nil {
-				return err
+				return fmt.Errorf("parse ready key: %w", err)
 			}
-			if claimed != nil {
-				return nil // stop after first ready message
+			msgKey := messageKey(queueId, seq, msgID)
+
+			msgItem, err := txn.Get(msgKey)
+			if err != nil {
+				if err == badger.ErrKeyNotFound {
+					txn.Delete(rKey)
+					continue
+				}
+				return fmt.Errorf("get message for ready key: %w", err)
 			}
+
+			var msg Message
+			if err := msgItem.Value(func(v []byte) error {
+				return json.Unmarshal(v, &msg)
+			}); err != nil {
+				return fmt.Errorf("unmarshal message: %w", err)
+			}
+
+			if msg.State != StateReady {
+				txn.Delete(rKey)
+				continue
+			}
+
+			if err := txn.Delete(rKey); err != nil {
+				return fmt.Errorf("delete ready key: %w", err)
+			}
+
+			msg.State = StateInFlight
+			msg.VisibilityDeadline = time.Now().Add(30 * time.Second)
+			msg.DeliveryCount++
+			msg.DeliveryAttemptID = uuid.NewString()
+
+			updated, err := json.Marshal(msg)
+			if err != nil {
+				return fmt.Errorf("marshal claimed message: %w", err)
+			}
+			if err := txn.Set(msgKey, updated); err != nil {
+				return fmt.Errorf("set claimed message: %w", err)
+			}
+
+			claimed = &msg
+			return nil
 		}
 		return nil
 	})
-	return claimed, err
+	if err != nil {
+		return nil, err
+	}
+	if claimed == nil {
+		return nil, ErrNoReadyMessages
+	}
+return claimed, nil
 }
 
 func receive(w http.ResponseWriter, r *http.Request) {
@@ -576,29 +600,28 @@ func receive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var msg *Message
+	var claimErr error
 
 	if wait := params.Get("wait"); wait == "true" {
-		msg, err = claimNextReadyMessage(id)
-		if err != nil {
-			http.Error(w, "Error retrieving message: "+err.Error(), http.StatusInternalServerError)
+		msg, claimErr = claimNextReadyMessage(id)
+		if claimErr != nil && claimErr != ErrNoReadyMessages {
+			http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
 			return
 		}
-		if msg == nil {
+		if claimErr == ErrNoReadyMessages {
 			readyCh := queueReadyChan(id)
 
-			// Re-check after subscribing to avoid missing a publish between the
-			// initial claim attempt and the wait setup.
-			msg, err = claimNextReadyMessage(id)
-			if err != nil {
-				http.Error(w, "Error retrieving message: "+err.Error(), http.StatusInternalServerError)
+			msg, claimErr = claimNextReadyMessage(id)
+			if claimErr != nil && claimErr != ErrNoReadyMessages {
+				http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
 				return
 			}
-			if msg == nil {
+			if claimErr == ErrNoReadyMessages {
 				timer := time.NewTimer(30 * time.Second)
 				defer timer.Stop()
 				select {
 				case <-readyCh:
-					msg, err = claimNextReadyMessage(id)
+					msg, claimErr = claimNextReadyMessage(id)
 				case <-timer.C:
 					// timed out — fall through with msg == nil
 				case <-r.Context().Done():
@@ -607,14 +630,14 @@ func receive(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		msg, err = claimNextReadyMessage(id)
+		msg, claimErr = claimNextReadyMessage(id)
 	}
 
-	if err != nil {
-		http.Error(w, "Error retrieving message: "+err.Error(), http.StatusInternalServerError)
+	if claimErr != nil && claimErr != ErrNoReadyMessages {
+		http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
 		return
 	}
-	if msg == nil {
+	if claimErr == ErrNoReadyMessages || msg == nil {
 		http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -26,6 +27,8 @@ type ErrDeliveryTokenMismatch struct {
 func (e *ErrDeliveryTokenMismatch) Error() string {
 	return fmt.Sprintf("delivery token mismatch: expected %q, got %q", e.Expected, e.Got)
 }
+
+var ErrNoReadyMessages = errors.New("no ready messages")
 
 type MessageState string
 
@@ -204,6 +207,37 @@ func nextMessageSequence(queueID string) (uint64, error) {
 	defer seq.Release()
 
 	return seq.Next()
+}
+
+const readyKeySep = "|"
+
+func readyKey(queueID string, seq uint64, messageID string) []byte {
+	prefix := readyPrefix(queueID)
+	key := make([]byte, 0, len(prefix)+8+1+len(messageID))
+	key = append(key, prefix...)
+	var seqBytes [8]byte
+	binary.BigEndian.PutUint64(seqBytes[:], seq)
+	key = append(key, seqBytes[:]...)
+	key = append(key, '|')
+	key = append(key, messageID...)
+	return key
+}
+
+func readyPrefix(queueID string) []byte {
+	return []byte("ready|" + queueID + readyKeySep)
+}
+
+func parseReadyKey(key []byte) (seq uint64, messageID string, err error) {
+	parts := bytes.SplitN(key, []byte(readyKeySep), 4)
+	if len(parts) != 4 || string(parts[0]) != "ready" {
+		return 0, "", fmt.Errorf("invalid ready key format: %s", string(key))
+	}
+	if len(parts[2]) != 8 {
+		return 0, "", fmt.Errorf("invalid seq in ready key: %s", string(key))
+	}
+	seq = binary.BigEndian.Uint64(parts[2])
+	messageID = string(parts[3])
+	return seq, messageID, nil
 }
 
 func findMessageRecord(txn *badger.Txn, queueID, messageID string) ([]byte, *Message, error) {

--- a/main.go
+++ b/main.go
@@ -866,9 +866,17 @@ type reapTransition struct {
 }
 
 func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
-	transitions := []reapTransition{}
+	type expiredMsg struct {
+		queueID     string
+		msgID       string
+		key         []byte
+		originalSeq uint64
+		toDead      bool
+	}
 
-	err := Db.Update(func(txn *badger.Txn) error {
+	var expired []expiredMsg
+
+	err := Db.View(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
 		opts.PrefetchValues = true
 		it := txn.NewIterator(opts)
@@ -886,7 +894,7 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 			}
 			queueID := string(key[:pipeIndex])
 
-			err := item.Value(func(v []byte) error {
+			if err := item.Value(func(v []byte) error {
 				var msg Message
 				if err := json.Unmarshal(v, &msg); err != nil {
 					return err
@@ -898,34 +906,88 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 					return nil
 				}
 
-				if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
-					msg.State = StateDead
-				} else {
-					msg.State = StateReady
-				}
-				msg.VisibilityDeadline = time.Time{}
-				msg.DeliveryAttemptID = ""
-
-				updated, err := json.Marshal(msg)
+				originalSeq, err := parseMessageKeySeq(key)
 				if err != nil {
 					return err
 				}
-				if err := txn.Set(item.KeyCopy(nil), updated); err != nil {
-					return err
-				}
 
-				transitions = append(transitions, reapTransition{QueueID: queueID, ToState: msg.State})
+				toDead := msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount
+				expired = append(expired, expiredMsg{
+					queueID:     queueID,
+					msgID:       msg.ID,
+					key:         key,
+					originalSeq: originalSeq,
+					toDead:      toDead,
+				})
 				return nil
-			})
-			if err != nil {
+			}); err != nil {
 				return err
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
 
+	transitions := make([]reapTransition, 0, len(expired))
+
+	err = Db.Update(func(txn *badger.Txn) error {
+		for _, exp := range expired {
+			item, err := txn.Get(exp.key)
+			if err != nil {
+				if err == badger.ErrKeyNotFound {
+					continue
+				}
+				return err
+			}
+
+			var msg Message
+			if err := item.Value(func(v []byte) error {
+				return json.Unmarshal(v, &msg)
+			}); err != nil {
+				return err
+			}
+
+			if msg.State != StateInFlight {
+				continue
+			}
+			if msg.VisibilityDeadline.IsZero() || now.Before(msg.VisibilityDeadline) {
+				continue
+			}
+
+			if exp.toDead {
+				msg.State = StateDead
+			} else {
+				msg.State = StateReady
+			}
+			msg.VisibilityDeadline = time.Time{}
+			msg.DeliveryAttemptID = ""
+
+			updated, err := json.Marshal(msg)
+			if err != nil {
+				return err
+			}
+			if err := txn.Set(exp.key, updated); err != nil {
+				return err
+			}
+
+			if msg.State == StateReady {
+				newSeq, err := nextMessageSequence(exp.queueID)
+				if err != nil {
+					return fmt.Errorf("allocate reaper sequence: %w", err)
+				}
+				if err := txn.Set(readyKey(exp.queueID, newSeq, exp.msgID), readyValue(exp.originalSeq)); err != nil {
+					return err
+				}
+			}
+
+			transitions = append(transitions, reapTransition{QueueID: exp.queueID, ToState: msg.State})
+		}
 		return nil
 	})
 
-	return transitions, err
+return transitions, err
 }
 
 // runs every second and resets expired in-flight messages back to ready in Badger.

--- a/main.go
+++ b/main.go
@@ -227,6 +227,30 @@ func readyPrefix(queueID string) []byte {
 	return []byte("ready|" + queueID + readyKeySep)
 }
 
+func readyValue(originalSeq uint64) []byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], originalSeq)
+	return buf[:]
+}
+
+func parseReadyValue(val []byte) (uint64, error) {
+	if len(val) != 8 {
+		return 0, fmt.Errorf("invalid ready value length: %d", len(val))
+	}
+	return binary.BigEndian.Uint64(val), nil
+}
+
+func parseMessageKeySeq(key []byte) (uint64, error) {
+	parts := bytes.SplitN(key, []byte("|"), 3)
+	if len(parts) < 2 {
+		return 0, fmt.Errorf("invalid message key format")
+	}
+	if len(parts[1]) != 8 {
+		return 0, fmt.Errorf("invalid seq in message key")
+	}
+	return binary.BigEndian.Uint64(parts[1]), nil
+}
+
 func parseReadyKey(key []byte) (seq uint64, messageID string, err error) {
 	parts := bytes.SplitN(key, []byte(readyKeySep), 4)
 	if len(parts) != 4 || string(parts[0]) != "ready" {
@@ -474,7 +498,7 @@ func publish(w http.ResponseWriter, r *http.Request) {
 		if err := txn.Set(messageKey(queueId, seq, message.Message.ID), messageJson); err != nil {
 			return err
 		}
-		return txn.Set(readyKey(queueId, seq, message.Message.ID), []byte{})
+		return txn.Set(readyKey(queueId, seq, message.Message.ID), readyValue(seq))
 	})
 	if err != nil {
 		http.Error(w, "Error Saving Message: "+err.Error(), http.StatusInternalServerError)
@@ -506,7 +530,7 @@ func claimNextReadyMessage(queueId string) (*Message, error) {
 	var claimed *Message
 	err := Db.Update(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
-		opts.PrefetchValues = false
+		opts.PrefetchValues = true
 		opts.Prefix = readyPrefix(queueId)
 		it := txn.NewIterator(opts)
 		defer it.Close()
@@ -514,11 +538,20 @@ func claimNextReadyMessage(queueId string) (*Message, error) {
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
 			rKey := item.KeyCopy(nil)
-			seq, msgID, err := parseReadyKey(rKey)
+			_, msgID, err := parseReadyKey(rKey)
 			if err != nil {
 				return fmt.Errorf("parse ready key: %w", err)
 			}
-			msgKey := messageKey(queueId, seq, msgID)
+
+			var originalSeq uint64
+			if err := item.Value(func(v []byte) error {
+				originalSeq, err = parseReadyValue(v)
+				return err
+			}); err != nil {
+				return fmt.Errorf("parse ready value: %w", err)
+			}
+
+			msgKey := messageKey(queueId, originalSeq, msgID)
 
 			msgItem, err := txn.Get(msgKey)
 			if err != nil {
@@ -744,7 +777,9 @@ func nack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var nackResultState MessageState
+var nackResultState MessageState
+	var needReadyPointer bool
+
 	err = Db.Update(func(txn *badger.Txn) error {
 		if _, err := txn.Get([]byte(ackReq.QueueId)); err != nil {
 			return err
@@ -768,13 +803,32 @@ func nack(w http.ResponseWriter, r *http.Request) {
 		msg.DeliveryAttemptID = ""
 
 		nackResultState = msg.State
+		needReadyPointer = nackResultState == StateReady
 
 		updated, err := json.Marshal(msg)
 		if err != nil {
 			return err
 		}
 
-		return txn.Set(key, updated)
+		if err := txn.Set(key, updated); err != nil {
+			return err
+		}
+
+		if needReadyPointer {
+			originalSeq, err := parseMessageKeySeq(key)
+			if err != nil {
+				return fmt.Errorf("parse message key seq: %w", err)
+			}
+			newSeq, err := nextMessageSequence(ackReq.QueueId)
+			if err != nil {
+				return fmt.Errorf("allocate nack sequence: %w", err)
+			}
+			if err := txn.Set(readyKey(ackReq.QueueId, newSeq, ackReq.MessageId), readyValue(originalSeq)); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	})
 	if err != nil {
 		if err == badger.ErrKeyNotFound {

--- a/main.go
+++ b/main.go
@@ -252,15 +252,25 @@ func parseMessageKeySeq(key []byte) (uint64, error) {
 }
 
 func parseReadyKey(key []byte) (seq uint64, messageID string, err error) {
-	parts := bytes.SplitN(key, []byte(readyKeySep), 4)
-	if len(parts) != 4 || string(parts[0]) != "ready" {
-		return 0, "", fmt.Errorf("invalid ready key format: %s", string(key))
+	// Key format: ready|<queueID>|<8-byte-seq>|<messageID>
+	// Find the start of the seq by locating the second '|' after "ready|"
+	firstPipe := bytes.IndexByte(key, '|')
+	if firstPipe == -1 {
+		return 0, "", fmt.Errorf("invalid ready key: no pipes: %s", string(key))
 	}
-	if len(parts[2]) != 8 {
-		return 0, "", fmt.Errorf("invalid seq in ready key: %s", string(key))
+	secondPipe := bytes.IndexByte(key[firstPipe+1:], '|')
+	if secondPipe == -1 {
+		return 0, "", fmt.Errorf("invalid ready key: missing queueID delimiter: %s", string(key))
 	}
-	seq = binary.BigEndian.Uint64(parts[2])
-	messageID = string(parts[3])
+	seqStart := firstPipe + 1 + secondPipe + 1
+	if seqStart+8 > len(key) {
+		return 0, "", fmt.Errorf("invalid ready key: too short: %s", string(key))
+	}
+	seq = binary.BigEndian.Uint64(key[seqStart : seqStart+8])
+	if key[seqStart+8] != '|' {
+		return 0, "", fmt.Errorf("invalid ready key: missing delimiter after seq: %s", string(key))
+	}
+	messageID = string(key[seqStart+8+1:])
 	return seq, messageID, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -861,6 +861,10 @@ var nackResultState MessageState
 		"state":   nackResultState,
 	})
 
+	if needReadyPointer {
+		signalQueueReady(ackReq.QueueId)
+	}
+
 	m := getOrCreateMetrics(ackReq.QueueId)
 	m.totalNacked.Add(1)
 	m.inFlightCount.Add(-1)

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -608,4 +609,83 @@ func TestQueueHandler(t *testing.T) {
 	if got := recorder.Body.String(); got != "Hello Consumer\n" {
 		t.Fatalf("unexpected body %q", got)
 	}
+}
+
+func BenchmarkReceiveLatencyVsDepth(b *testing.B) {
+	depths := []int{100, 1000, 10000}
+	for _, depth := range depths {
+		b.Run(fmt.Sprintf("depth_%d", depth), func(b *testing.B) {
+			db, err := badger.Open(badger.DefaultOptions(b.TempDir()).WithLogger(nil))
+			if err != nil {
+				b.Fatalf("open db: %v", err)
+			}
+			Db = db
+			metricsStore = sync.Map{}
+			receiveChannel = make(chan struct{}, 1)
+			queueReadyChans = map[string]chan struct{}{}
+			b.Cleanup(func() {
+				db.Close()
+				Db = nil
+			})
+
+			queueID := createBenchQueue(b, "bench-queue")
+
+			for i := 0; i < depth; i++ {
+				publishBenchMessage(b, queueID, []byte("fill"))
+			}
+
+			for i := 0; i < depth; i++ {
+				receiveBenchMessage(b, queueID)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				publishBenchMessage(b, queueID, []byte("lat"))
+				receiveBenchMessage(b, queueID)
+			}
+		})
+	}
+}
+
+func createBenchQueue(b testing.TB, name string) string {
+	b.Helper()
+	body, _ := json.Marshal(CreateRequest{Name: name, MaxRetries: 3})
+	req := httptest.NewRequest(http.MethodPost, "/create", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	create(rec, req)
+	if rec.Code != http.StatusAccepted {
+		b.Fatalf("create status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		ID string `json:"id"`
+	}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	return resp.ID
+}
+
+func publishBenchMessage(b testing.TB, queueID string, body []byte) {
+	b.Helper()
+	msgBody, _ := json.Marshal(PublishRequest{
+		Message: Message{Body: body},
+		QueueId: queueID,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/publish", bytes.NewReader(msgBody))
+	rec := httptest.NewRecorder()
+	publish(rec, req)
+	if rec.Code != http.StatusAccepted {
+		b.Fatalf("publish status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func receiveBenchMessage(b testing.TB, queueID string) receiveResponse {
+	b.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID, nil)
+	rec := httptest.NewRecorder()
+	receive(rec, req)
+	if rec.Code != http.StatusAccepted {
+		b.Fatalf("receive status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp receiveResponse
+	json.NewDecoder(rec.Body).Decode(&resp)
+	return resp
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster, more efficient message claiming and queue scanning for lower publish/receive latency.
  * Improved expired-message cleanup for quicker recovery of ready messages.

* **Reliability / Bug Fixes**
  * Receive now treats lack of ready messages as a normal condition, avoiding spurious internal errors.
  * NACKed and reaped messages are more reliably returned to ready state for re-delivery.

* **Tests**
  * Added end-to-end latency benchmarks across queue depths (100, 1,000, 10,000).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->