### PR TITLE
fix: use min(60, uptime) as divisor in ackRatePerSec

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"sync"
@@ -118,7 +119,7 @@ func (m *queueMetrics) ackRatePerSec() float64 {
 	if len(m.ackWindow) == 0 {
 		return 0
 	}
-	return float64(len(m.ackWindow)) / 60.0
+	return float64(len(m.ackWindow)) / math.Min(60.0, time.Since(m.startedAt).Seconds())
 }
 
 func getOrCreateMetrics(queueID string) *queueMetrics {

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -674,6 +675,50 @@ func publishBenchMessage(b testing.TB, queueID string, body []byte) {
 	publish(rec, req)
 	if rec.Code != http.StatusAccepted {
 		b.Fatalf("publish status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAckRatePerSec_NewQueue(t *testing.T) {
+	m := &queueMetrics{
+		startedAt: time.Now().Add(-5 * time.Second),
+	}
+	for i := 0; i < 10; i++ {
+		m.ackWindow = append(m.ackWindow, time.Now())
+	}
+
+	rate := m.ackRatePerSec()
+
+	elapsed := math.Min(60.0, 5.0)
+	expected := 10.0 / elapsed
+	if math.Abs(rate-expected) > 0.01 {
+		t.Errorf("ackRatePerSec = %.4f, want %.4f", rate, expected)
+	}
+}
+
+func TestAckRatePerSec_MatureQueue(t *testing.T) {
+	m := &queueMetrics{
+		startedAt: time.Now().Add(-120 * time.Second),
+	}
+	for i := 0; i < 60; i++ {
+		m.ackWindow = append(m.ackWindow, time.Now())
+	}
+
+	rate := m.ackRatePerSec()
+
+	expected := 1.0
+	if math.Abs(rate-expected) > 0.01 {
+		t.Errorf("ackRatePerSec = %.4f, want %.4f", rate, expected)
+	}
+}
+
+func TestAckRatePerSec_EmptyWindow(t *testing.T) {
+	m := &queueMetrics{
+		startedAt: time.Now(),
+	}
+
+	rate := m.ackRatePerSec()
+	if rate != 0 {
+		t.Errorf("ackRatePerSec = %.4f, want 0", rate)
 	}
 }
 


### PR DESCRIPTION
## Summary

- \ckRatePerSec\ divided by a hard-coded \60.0\, which understated the rate for queues younger than 60 seconds
- Changed the divisor to \min(60.0, seconds_since_startedAt)\ so newly created queues report an accurate rate
- Added unit tests covering the new-queue (short uptime), mature-queue (uptime > 60s), and empty-window cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of acknowledgment rate metric calculations during system startup by adjusting the calculation window based on elapsed uptime.

* **Tests**
  * Added unit tests for acknowledgment rate calculation covering new queue, mature queue, and empty window scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->