### PR TITLE
Reduce ready index consume overhead

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -635,8 +635,9 @@ func (t *kueueTarget) receive(ctx context.Context, wait bool) (*delivery, error)
 	switch resp.StatusCode {
 	case http.StatusAccepted:
 		var payload struct {
-			ID   string `json:"id"`
-			Body []byte `json:"body"`
+			ID            string `json:"id"`
+			Body          []byte `json:"body"`
+			DeliveryToken string `json:"deliveryToken"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 			return nil, err
@@ -646,12 +647,14 @@ func (t *kueueTarget) receive(ctx context.Context, wait bool) (*delivery, error)
 			Body: payload.Body,
 			Ack: func(ctx context.Context) error {
 				type ackRequest struct {
-					MessageID string `json:"messageId"`
-					QueueID   string `json:"queueId"`
+					MessageID     string `json:"messageId"`
+					QueueID       string `json:"queueId"`
+					DeliveryToken string `json:"deliveryToken"`
 				}
 				return t.postJSON(ctx, "/ack", ackRequest{
-					MessageID: payload.ID,
-					QueueID:   t.queueID,
+					MessageID:     payload.ID,
+					QueueID:       t.queueID,
+					DeliveryToken: payload.DeliveryToken,
 				}, nil)
 			},
 		}, nil

--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestKueueTargetAckIncludesDeliveryToken(t *testing.T) {
+	type ackRequest struct {
+		MessageID     string `json:"messageId"`
+		QueueID       string `json:"queueId"`
+		DeliveryToken string `json:"deliveryToken"`
+	}
+
+	ackRequests := make(chan ackRequest, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/receive":
+			if r.URL.Query().Get("id") != "queue-1" {
+				http.Error(w, "wrong queue id", http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"id":            "message-1",
+				"body":          []byte("payload"),
+				"deliveryToken": "token-1",
+			}); err != nil {
+				t.Errorf("encode receive response: %v", err)
+			}
+		case "/ack":
+			var req ackRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "bad ack request", http.StatusBadRequest)
+				return
+			}
+			ackRequests <- req
+			w.WriteHeader(http.StatusAccepted)
+			if err := json.NewEncoder(w).Encode(map[string]any{"ok": true}); err != nil {
+				t.Errorf("encode ack response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	target := newKueueTarget(server.URL)
+	target.queueID = "queue-1"
+
+	msg, err := target.Consume(context.Background())
+	if err != nil {
+		t.Fatalf("Consume returned error: %v", err)
+	}
+	if err := msg.Ack(context.Background()); err != nil {
+		t.Fatalf("Ack returned error: %v", err)
+	}
+
+	select {
+	case req := <-ackRequests:
+		if req.MessageID != "message-1" {
+			t.Fatalf("ack message id = %q, want message-1", req.MessageID)
+		}
+		if req.QueueID != "queue-1" {
+			t.Fatalf("ack queue id = %q, want queue-1", req.QueueID)
+		}
+		if req.DeliveryToken != "token-1" {
+			t.Fatalf("ack delivery token = %q, want token-1", req.DeliveryToken)
+		}
+	default:
+		t.Fatal("ack endpoint was not called")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -584,7 +584,9 @@ func claimNextReadyMessage(queueId string) (*Message, error) {
 					msgKey = messageKeyBytes(queueId, originalSeq, msgID)
 					msgItem, err = txn.Get(msgKey)
 					if err == badger.ErrKeyNotFound {
-						txn.Delete(rKey)
+						if err := txn.Delete(rKey); err != nil {
+							return fmt.Errorf("delete stale ready pointer %x: %w", rKey, err)
+						}
 						continue
 					}
 				}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"sync"
@@ -118,7 +119,7 @@ func (m *queueMetrics) ackRatePerSec() float64 {
 	if len(m.ackWindow) == 0 {
 		return 0
 	}
-	return float64(len(m.ackWindow)) / 60.0
+	return float64(len(m.ackWindow)) / math.Min(60.0, time.Since(m.startedAt).Seconds())
 }
 
 func getOrCreateMetrics(queueID string) *queueMetrics {

--- a/main.go
+++ b/main.go
@@ -196,6 +196,20 @@ func messageKey(queueID string, seq uint64, messageID string) []byte {
 	return key
 }
 
+func messageKeyBytes(queueID string, seq uint64, messageID []byte) []byte {
+	prefix := queueMessagePrefix(queueID)
+	key := make([]byte, 0, len(prefix)+8+1+len(messageID))
+	key = append(key, prefix...)
+
+	var seqBytes [8]byte
+	binary.BigEndian.PutUint64(seqBytes[:], seq)
+	key = append(key, seqBytes[:]...)
+	key = append(key, '|')
+	key = append(key, messageID...)
+
+	return key
+}
+
 func queueSequenceKey(queueID string) []byte {
 	return []byte("seq:" + queueID)
 }
@@ -254,27 +268,21 @@ func parseMessageKeySeq(key []byte) (uint64, error) {
 	return binary.BigEndian.Uint64(key[seqStart:seqEnd]), nil
 }
 
-func parseReadyKey(key []byte) (seq uint64, messageID string, err error) {
-	// Key format: ready|<queueID>|<8-byte-seq>|<messageID>
-	// Find the start of the seq by locating the second '|' after "ready|"
-	firstPipe := bytes.IndexByte(key, '|')
-	if firstPipe == -1 {
-		return 0, "", fmt.Errorf("invalid ready key: no pipes: %s", string(key))
+func readyPartsFromKey(key, prefix []byte) (uint64, []byte, error) {
+	if !bytes.HasPrefix(key, prefix) {
+		return 0, nil, fmt.Errorf("ready key does not match prefix")
 	}
-	secondPipe := bytes.IndexByte(key[firstPipe+1:], '|')
-	if secondPipe == -1 {
-		return 0, "", fmt.Errorf("invalid ready key: missing queueID delimiter: %s", string(key))
+	rest := key[len(prefix):]
+	if len(rest) < 9 {
+		return 0, nil, fmt.Errorf("invalid ready key: too short")
 	}
-	seqStart := firstPipe + 1 + secondPipe + 1
-	if seqStart+8 > len(key) {
-		return 0, "", fmt.Errorf("invalid ready key: too short: %s", string(key))
+	if rest[8] != '|' {
+		return 0, nil, fmt.Errorf("invalid ready key: missing delimiter after seq")
 	}
-	seq = binary.BigEndian.Uint64(key[seqStart : seqStart+8])
-	if key[seqStart+8] != '|' {
-		return 0, "", fmt.Errorf("invalid ready key: missing delimiter after seq: %s", string(key))
+	if len(rest[9:]) == 0 {
+		return 0, nil, fmt.Errorf("invalid ready key: missing message id")
 	}
-	messageID = string(key[seqStart+8+1:])
-	return seq, messageID, nil
+	return binary.BigEndian.Uint64(rest[:8]), rest[9:], nil
 }
 
 func findMessageRecord(txn *badger.Txn, queueID, messageID string) ([]byte, *Message, error) {
@@ -543,36 +551,46 @@ func claimNextReadyMessage(queueId string) (*Message, error) {
 	var claimed *Message
 	err := Db.Update(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
-		opts.PrefetchValues = true
-		opts.Prefix = readyPrefix(queueId)
+		opts.PrefetchValues = false
+		prefix := readyPrefix(queueId)
+		opts.Prefix = prefix
 		it := txn.NewIterator(opts)
 		defer it.Close()
 
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
 			rKey := item.KeyCopy(nil)
-			_, msgID, err := parseReadyKey(rKey)
+			readySeq, msgID, err := readyPartsFromKey(rKey, prefix)
 			if err != nil {
 				return fmt.Errorf("parse ready key: %w", err)
 			}
 
-			var originalSeq uint64
-			if err := item.Value(func(v []byte) error {
-				originalSeq, err = parseReadyValue(v)
-				return err
-			}); err != nil {
-				return fmt.Errorf("parse ready value: %w", err)
-			}
-
-			msgKey := messageKey(queueId, originalSeq, msgID)
-
+			msgKey := messageKeyBytes(queueId, readySeq, msgID)
 			msgItem, err := txn.Get(msgKey)
 			if err != nil {
 				if err == badger.ErrKeyNotFound {
-					txn.Delete(rKey)
-					continue
+					var originalSeq uint64
+					valueErr := item.Value(func(v []byte) error {
+						parsedSeq, parseErr := parseReadyValue(v)
+						if parseErr != nil {
+							return parseErr
+						}
+						originalSeq = parsedSeq
+						return nil
+					})
+					if valueErr != nil {
+						return fmt.Errorf("parse ready value: %w", valueErr)
+					}
+					msgKey = messageKeyBytes(queueId, originalSeq, msgID)
+					msgItem, err = txn.Get(msgKey)
+					if err == badger.ErrKeyNotFound {
+						txn.Delete(rKey)
+						continue
+					}
 				}
-				return fmt.Errorf("get message for ready key: %w", err)
+				if err != nil {
+					return fmt.Errorf("get message for ready key: %w", err)
+				}
 			}
 
 			var msg Message
@@ -615,7 +633,7 @@ func claimNextReadyMessage(queueId string) (*Message, error) {
 	if claimed == nil {
 		return nil, ErrNoReadyMessages
 	}
-return claimed, nil
+	return claimed, nil
 }
 
 func receive(w http.ResponseWriter, r *http.Request) {
@@ -794,7 +812,7 @@ func nack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-var nackResultState MessageState
+	var nackResultState MessageState
 	var needReadyPointer bool
 
 	err = Db.Update(func(txn *badger.Txn) error {
@@ -1008,7 +1026,7 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 		return nil
 	})
 
-return transitions, err
+	return transitions, err
 }
 
 // runs every second and resets expired in-flight messages back to ready in Badger.

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -674,6 +675,50 @@ func publishBenchMessage(b testing.TB, queueID string, body []byte) {
 	publish(rec, req)
 	if rec.Code != http.StatusAccepted {
 		b.Fatalf("publish status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAckRatePerSec_NewQueue(t *testing.T) {
+	m := &queueMetrics{
+		startedAt: time.Now().Add(-5 * time.Second),
+	}
+	for i := 0; i < 10; i++ {
+		m.ackWindow = append(m.ackWindow, time.Now())
+	}
+
+	rate := m.ackRatePerSec()
+
+	elapsed := math.Min(60.0, 5.0)
+	expected := 10.0 / elapsed
+	if math.Abs(rate-expected) > 0.01 {
+		t.Errorf("ackRatePerSec = %.4f, want %.4f", rate, expected)
+	}
+}
+
+func TestAckRatePerSec_MatureQueue(t *testing.T) {
+	m := &queueMetrics{
+		startedAt: time.Now().Add(-120 * time.Second),
+	}
+	for i := 0; i < 60; i++ {
+		m.ackWindow = append(m.ackWindow, time.Now())
+	}
+
+	rate := m.ackRatePerSec()
+
+	expected := 1.0
+	if math.Abs(rate-expected) > 0.01 {
+		t.Errorf("ackRatePerSec = %.4f, want %.4f", rate, expected)
+	}
+}
+
+func TestAckRatePerSec_EmptyWindow(t *testing.T) {
+	m := &queueMetrics{
+		startedAt: time.Now(),
+	}
+
+	rate := m.ackRatePerSec()
+	if rate != 0 {
+		t.Errorf("ackRatePerSec = %.4f, want 0", rate)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -143,6 +143,26 @@ func receiveTestMessage(t *testing.T, queueID string) receiveResponse {
 	return decodeResponse[receiveResponse](t, recorder)
 }
 
+func TestReadyPartsFromKeyUsesKnownPrefix(t *testing.T) {
+	prefix := readyPrefix("queue-a")
+	key := readyKey("queue-a", 0x7c, "message-1")
+
+	seq, msgID, err := readyPartsFromKey(key, prefix)
+	if err != nil {
+		t.Fatalf("readyPartsFromKey returned error: %v", err)
+	}
+	if seq != 0x7c {
+		t.Fatalf("ready seq = %d, want %d", seq, 0x7c)
+	}
+	if string(msgID) != "message-1" {
+		t.Fatalf("message id = %q, want message-1", string(msgID))
+	}
+
+	if _, _, err := readyPartsFromKey(key, readyPrefix("queue-b")); err == nil {
+		t.Fatal("expected mismatched prefix error")
+	}
+}
+
 func TestCreateAndGetQueue(t *testing.T) {
 	setupTestDB(t)
 


### PR DESCRIPTION
Summary:
- optimize ready-index claim to avoid ready-value reads on fresh messages and disable unnecessary ready iterator value prefetch
- keep fallback for requeued ready pointers whose ready sequence differs from original message sequence
- update cmd/bench kueue ack requests to include deliveryToken

Tests:
- go test -count=1 ./...
- go build ./...
- smoke benchmark: go run ./cmd/bench -targets kueue -messages 200 -warmup 20 -runs 1 -payload-bytes 256 -producers 1 -consumers 1 -prefetch 50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Acknowledgment requests now include a delivery token from receive responses to improve message tracking.

* **Improvements**
  * Refined ack-rate calculation for more accurate metrics reporting.

* **Tests**
  * Added unit tests validating acknowledgment payloads, key parsing behavior, and ack-rate computation across edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->