### PR TITLE
feat: batch receive and batch ack with leveled benchmark

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -21,6 +21,14 @@ import (
 
 var errNoMessage = errors.New("no message available")
 
+var debugLog bool
+
+func debugf(format string, args ...any) {
+	if debugLog {
+		fmt.Fprintf(os.Stderr, "[bench] "+format+"\n", args...)
+	}
+}
+
 type workloadConfig struct {
 	Messages       int      `json:"messages"`
 	Warmup         int      `json:"warmup"`
@@ -106,7 +114,10 @@ func main() {
 	)
 	flag.Parse()
 
+	debugLog = os.Getenv("DEBUG") == "true"
+
 	targetList := parseTargets(*targets)
+	debugf("targets: %v, messages: %d, runs: %d", targetList, *messages, *runs)
 
 	// --- Section 1: End-to-end (default client config) ---
 	e2eCfg := workloadConfig{
@@ -166,12 +177,15 @@ func runSection(label string, targetList []string, cfg workloadConfig, kueueURL,
 		os.Exit(1)
 	}
 
+	debugf("--- section: %s (batch=%d, prefetch=%d) ---", label, cfg.KueueBatchSize, cfg.Prefetch)
+
 	report := benchmarkReport{
 		GeneratedAt: time.Now().UTC(),
 		Workload:    cfg,
 	}
 
 	for _, name := range targetList {
+		debugf("target: %s", name)
 		target, err := newTarget(name, kueueURL, rabbitMQURI)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: target %q: %v\n", label, name, err)
@@ -256,19 +270,23 @@ func runTarget(ctx context.Context, target benchmarkTarget, cfg workloadConfig) 
 	fmt.Printf("\n== %s ==\n", strings.ToUpper(target.Name()))
 
 	for run := 1; run <= cfg.Runs; run++ {
+		debugf("setup run %d/%d", run, cfg.Runs)
 		runLabel := fmt.Sprintf("%s-%d-%d", target.Name(), run, time.Now().UnixNano())
 		if err := target.Setup(ctx, cfg, runLabel); err != nil {
 			return summary, err
 		}
 
 		if cfg.Warmup > 0 {
+			debugf("warmup: %d messages...", cfg.Warmup)
 			if _, err := executeWorkload(ctx, target, cfg, cfg.Warmup); err != nil {
 				_ = target.Cleanup(context.Background())
 				return summary, fmt.Errorf("warmup run %d: %w", run, err)
 			}
 		}
 
+		debugf("measured run %d: %d messages...", run, cfg.Messages)
 		result, err := executeWorkload(ctx, target, cfg, cfg.Messages)
+		debugf("cleanup...")
 		cleanupErr := target.Cleanup(context.Background())
 		if err != nil {
 			return summary, fmt.Errorf("measured run %d: %w", run, err)
@@ -330,6 +348,21 @@ func executeWorkload(parent context.Context, target benchmarkTarget, cfg workloa
 		seqCh <- seq
 	}
 	close(seqCh)
+
+	doneCh := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(3 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				debugf("progress: produced=%d/%d consumed=%d/%d", produced.Load(), messages, consumed.Load(), messages)
+			case <-doneCh:
+				return
+			}
+		}
+	}()
+	defer close(doneCh)
 
 	consumeStarted := time.Now()
 	var consumerWG sync.WaitGroup
@@ -603,8 +636,8 @@ type receivedMsg struct {
 }
 
 type ackEntryBench struct {
-	MessageID     string
-	DeliveryToken string
+	MessageID     string `json:"messageId"`
+	DeliveryToken string `json:"deliveryToken"`
 }
 
 type kueueTarget struct {

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -694,12 +694,12 @@ func (t *kueueTarget) NewPublisher(int) (publisher, error) {
 }
 
 func (t *kueueTarget) Consume(ctx context.Context) (*delivery, error) {
+	// Fast path: return buffered message without I/O
 	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	if len(t.msgBuf) > 0 {
 		m := t.msgBuf[0]
 		t.msgBuf = t.msgBuf[1:]
+		t.mu.Unlock()
 		return &delivery{
 			ID:   m.ID,
 			Body: m.Body,
@@ -707,10 +707,22 @@ func (t *kueueTarget) Consume(ctx context.Context) (*delivery, error) {
 		}, nil
 	}
 
-	if err := t.flushAcksLocked(ctx); err != nil {
-		return nil, err
+	// Steal pending acks and clear them under lock
+	var acksToFlush []ackEntryBench
+	if len(t.pendingAcks) > 0 {
+		acksToFlush = t.pendingAcks
+		t.pendingAcks = nil
+	}
+	t.mu.Unlock()
+
+	// Flush acks without holding lock
+	if len(acksToFlush) > 0 {
+		if err := t.flushAcks(ctx, acksToFlush); err != nil {
+			return nil, err
+		}
 	}
 
+	// Receive batch without holding lock
 	msgs, err := t.receiveBatch(ctx)
 	if err != nil {
 		if errors.Is(err, errNoMessage) {
@@ -722,7 +734,24 @@ func (t *kueueTarget) Consume(ctx context.Context) (*delivery, error) {
 		return nil, errNoMessage
 	}
 
-	t.msgBuf = msgs[1:]
+	// Push to buffer and return one message
+	t.mu.Lock()
+	// Reconcile any pendingAcks added while we were waiting for network I/O
+	if len(t.pendingAcks) > 0 && len(msgs) > 1 {
+		// We have concurrent acks, might as well flush them now
+		t.mu.Unlock()
+		if err := t.flushAcks(ctx, t.pendingAcks); err != nil {
+			return nil, err
+		}
+		t.mu.Lock()
+		t.pendingAcks = nil
+	}
+
+	if len(msgs) > 1 {
+		t.msgBuf = append(t.msgBuf, msgs[1:]...)
+	}
+	t.mu.Unlock()
+
 	m := msgs[0]
 	return &delivery{
 		ID:   m.ID,
@@ -736,32 +765,49 @@ func (t *kueueTarget) makeAckFunc(msgID, deliveryToken string) func(context.Cont
 		t.mu.Lock()
 		t.pendingAcks = append(t.pendingAcks, ackEntryBench{MessageID: msgID, DeliveryToken: deliveryToken})
 		shouldFlush := len(t.pendingAcks) >= t.batchSize || len(t.msgBuf) == 0
+		var acksToFlush []ackEntryBench
+		if shouldFlush {
+			acksToFlush = t.pendingAcks
+			t.pendingAcks = nil
+		}
 		t.mu.Unlock()
 
 		if shouldFlush {
-			t.mu.Lock()
-			defer t.mu.Unlock()
-			return t.flushAcksLocked(ctx)
+			return t.flushAcks(ctx, acksToFlush)
 		}
 		return nil
 	}
 }
 
+// flushAcksLocked flushes t.pendingAcks. Must be called with t.mu held.
 func (t *kueueTarget) flushAcksLocked(ctx context.Context) error {
 	if len(t.pendingAcks) == 0 {
 		return nil
 	}
+	acks := t.pendingAcks
+	t.pendingAcks = nil
+	// Release lock during I/O
+	t.mu.Unlock()
+	err := t.flushAcks(ctx, acks)
+	t.mu.Lock()
+	return err
+}
+
+// flushAcks posts the given acks. Does NOT require t.mu to be held.
+func (t *kueueTarget) flushAcks(ctx context.Context, acks []ackEntryBench) error {
+	if len(acks) == 0 {
+		return nil
+	}
 
 	type batchReqBody struct {
-		QueueId string        `json:"queueId"`
+		QueueId string          `json:"queueId"`
 		Acks    []ackEntryBench `json:"acks"`
 	}
 
 	req := batchReqBody{
 		QueueId: t.queueID,
-		Acks:    t.pendingAcks,
+		Acks:    acks,
 	}
-	t.pendingAcks = nil
 
 	if err := t.postJSON(ctx, "/ack", req, nil); err != nil {
 		return err
@@ -821,11 +867,7 @@ func (t *kueueTarget) Cleanup(ctx context.Context) error {
 
 	var err error
 	if len(pending) > 0 {
-		t.mu.Lock()
-		t.pendingAcks = pending
-		err = t.flushAcksLocked(ctx)
-		t.pendingAcks = nil
-		t.mu.Unlock()
+		err = t.flushAcks(ctx, pending)
 	}
 
 	t.queueID = ""

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -22,14 +22,15 @@ import (
 var errNoMessage = errors.New("no message available")
 
 type workloadConfig struct {
-	Messages     int      `json:"messages"`
-	Warmup       int      `json:"warmup"`
-	Runs         int      `json:"runs"`
-	PayloadBytes int      `json:"payloadBytes"`
-	Producers    int      `json:"producers"`
-	Consumers    int      `json:"consumers"`
-	Prefetch     int      `json:"prefetch"`
-	Targets      []string `json:"targets"`
+	Messages       int      `json:"messages"`
+	Warmup         int      `json:"warmup"`
+	Runs           int      `json:"runs"`
+	PayloadBytes   int      `json:"payloadBytes"`
+	Producers      int      `json:"producers"`
+	Consumers      int      `json:"consumers"`
+	Prefetch       int      `json:"prefetch"`
+	Targets        []string `json:"targets"`
+	KueueBatchSize int      `json:"kueueBatchSize"`
 }
 
 type benchmarkPayload struct {
@@ -105,19 +106,63 @@ func main() {
 	)
 	flag.Parse()
 
-	cfg := workloadConfig{
-		Messages:     *messages,
-		Warmup:       *warmup,
-		Runs:         *runs,
-		PayloadBytes: *payloadBytes,
-		Producers:    *producers,
-		Consumers:    *consumers,
-		Prefetch:     *prefetch,
-		Targets:      parseTargets(*targets),
-	}
+	targetList := parseTargets(*targets)
 
+	// --- Section 1: End-to-end (default client config) ---
+	e2eCfg := workloadConfig{
+		Messages:       *messages,
+		Warmup:         *warmup,
+		Runs:           *runs,
+		PayloadBytes:   *payloadBytes,
+		Producers:      *producers,
+		Consumers:      *consumers,
+		Prefetch:       *prefetch,
+		Targets:        targetList,
+		KueueBatchSize: 10,
+	}
+	e2eReport := runSection("End-to-end (default client config)", targetList, e2eCfg, *kueueURL, *rabbitMQURI, "Note: measures protocol + broker together.")
+	printSection(e2eReport)
+
+	// --- Section 2: Apples-to-apples (one message per round-trip) ---
+	applesCfg := e2eCfg
+	applesCfg.Prefetch = 1
+	applesCfg.KueueBatchSize = 1
+	applesReport := runSection("Apples-to-apples (one message per round-trip)", targetList, applesCfg, *kueueURL, *rabbitMQURI, "Note: isolates broker behavior; not a realistic config for either.")
+	printSection(applesReport)
+
+	// Combined JSON output
+	if *jsonOut != "" {
+		sectionOutput := func(sr sectionReport) map[string]any {
+			return map[string]any{
+				"label":  sr.Label,
+				"note":   sr.Note,
+				"report": sr.Report,
+			}
+		}
+		data, err := json.MarshalIndent(map[string]any{
+			"generatedAt": time.Now().UTC(),
+			"sections":    []any{sectionOutput(e2eReport), sectionOutput(applesReport)},
+		}, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "marshal report: %v\n", err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(*jsonOut, data, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "write report: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+type sectionReport struct {
+	Label  string
+	Note   string
+	Report benchmarkReport
+}
+
+func runSection(label string, targetList []string, cfg workloadConfig, kueueURL, rabbitMQURI, note string) sectionReport {
 	if err := validateConfig(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		fmt.Fprintf(os.Stderr, "%s: invalid config: %v\n", label, err)
 		os.Exit(1)
 	}
 
@@ -126,30 +171,29 @@ func main() {
 		Workload:    cfg,
 	}
 
-	for _, name := range cfg.Targets {
-		target, err := newTarget(name, *kueueURL, *rabbitMQURI)
+	for _, name := range targetList {
+		target, err := newTarget(name, kueueURL, rabbitMQURI)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "target %q: %v\n", name, err)
+			fmt.Fprintf(os.Stderr, "%s: target %q: %v\n", label, name, err)
 			os.Exit(1)
 		}
 
 		summary, err := runTarget(context.Background(), target, cfg)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s benchmark failed: %v\n", target.Name(), err)
+			fmt.Fprintf(os.Stderr, "%s: %s benchmark failed: %v\n", label, target.Name(), err)
 			os.Exit(1)
 		}
 
 		report.Summaries = append(report.Summaries, summary)
 	}
 
-	printReport(report)
+	return sectionReport{Label: label, Note: note, Report: report}
+}
 
-	if *jsonOut != "" {
-		if err := writeReport(*jsonOut, report); err != nil {
-			fmt.Fprintf(os.Stderr, "write report: %v\n", err)
-			os.Exit(1)
-		}
-	}
+func printSection(s sectionReport) {
+	fmt.Printf("\n=== %s ===\n", s.Label)
+	printReport(s.Report)
+	fmt.Printf("--- %s ---\n", s.Note)
 }
 
 func parseTargets(raw string) []string {
@@ -552,10 +596,26 @@ func filepathDir(path string) string {
 	return path[:lastSlash]
 }
 
+type receivedMsg struct {
+	ID            string
+	Body          []byte
+	DeliveryToken string
+}
+
+type ackEntryBench struct {
+	MessageID     string
+	DeliveryToken string
+}
+
 type kueueTarget struct {
-	baseURL string
-	client  *http.Client
-	queueID string
+	baseURL    string
+	client     *http.Client
+	queueID    string
+	batchSize  int
+
+	mu          sync.Mutex
+	msgBuf      []receivedMsg
+	pendingAcks []ackEntryBench
 }
 
 func newKueueTarget(baseURL string) *kueueTarget {
@@ -564,6 +624,7 @@ func newKueueTarget(baseURL string) *kueueTarget {
 		client: &http.Client{
 			Timeout: 40 * time.Second,
 		},
+		batchSize: 10,
 	}
 }
 
@@ -589,6 +650,9 @@ func (t *kueueTarget) Setup(ctx context.Context, cfg workloadConfig, runLabel st
 	}
 
 	t.queueID = resp.ID
+	if cfg.KueueBatchSize > 0 {
+		t.batchSize = cfg.KueueBatchSize
+	}
 	return nil
 }
 
@@ -597,26 +661,83 @@ func (t *kueueTarget) NewPublisher(int) (publisher, error) {
 }
 
 func (t *kueueTarget) Consume(ctx context.Context) (*delivery, error) {
-	msg, err := t.receive(ctx, false)
-	if err == nil {
-		return msg, nil
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if len(t.msgBuf) > 0 {
+		m := t.msgBuf[0]
+		t.msgBuf = t.msgBuf[1:]
+		return &delivery{
+			ID:   m.ID,
+			Body: m.Body,
+			Ack:  t.makeAckFunc(m.ID, m.DeliveryToken),
+		}, nil
 	}
-	if !errors.Is(err, errNoMessage) {
+
+	if err := t.flushAcksLocked(ctx); err != nil {
 		return nil, err
 	}
-	return t.receive(ctx, true)
+
+	msgs, err := t.receiveBatch(ctx)
+	if err != nil {
+		if errors.Is(err, errNoMessage) {
+			return nil, errNoMessage
+		}
+		return nil, err
+	}
+	if len(msgs) == 0 {
+		return nil, errNoMessage
+	}
+
+	t.msgBuf = msgs[1:]
+	m := msgs[0]
+	return &delivery{
+		ID:   m.ID,
+		Body: m.Body,
+		Ack:  t.makeAckFunc(m.ID, m.DeliveryToken),
+	}, nil
 }
 
-func (t *kueueTarget) Cleanup(context.Context) error {
-	t.queueID = ""
+func (t *kueueTarget) makeAckFunc(msgID, deliveryToken string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		t.mu.Lock()
+		t.pendingAcks = append(t.pendingAcks, ackEntryBench{MessageID: msgID, DeliveryToken: deliveryToken})
+		shouldFlush := len(t.pendingAcks) >= t.batchSize || len(t.msgBuf) == 0
+		t.mu.Unlock()
+
+		if shouldFlush {
+			t.mu.Lock()
+			defer t.mu.Unlock()
+			return t.flushAcksLocked(ctx)
+		}
+		return nil
+	}
+}
+
+func (t *kueueTarget) flushAcksLocked(ctx context.Context) error {
+	if len(t.pendingAcks) == 0 {
+		return nil
+	}
+
+	type batchReqBody struct {
+		QueueId string        `json:"queueId"`
+		Acks    []ackEntryBench `json:"acks"`
+	}
+
+	req := batchReqBody{
+		QueueId: t.queueID,
+		Acks:    t.pendingAcks,
+	}
+	t.pendingAcks = nil
+
+	if err := t.postJSON(ctx, "/ack", req, nil); err != nil {
+		return err
+	}
 	return nil
 }
 
-func (t *kueueTarget) receive(ctx context.Context, wait bool) (*delivery, error) {
-	url := fmt.Sprintf("%s/receive?id=%s", t.baseURL, t.queueID)
-	if wait {
-		url += "&wait=true"
-	}
+func (t *kueueTarget) receiveBatch(ctx context.Context) ([]receivedMsg, error) {
+	url := fmt.Sprintf("%s/receive?id=%s&max=%d", t.baseURL, t.queueID, t.batchSize)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -635,29 +756,20 @@ func (t *kueueTarget) receive(ctx context.Context, wait bool) (*delivery, error)
 	switch resp.StatusCode {
 	case http.StatusAccepted:
 		var payload struct {
-			ID            string `json:"id"`
-			Body          []byte `json:"body"`
-			DeliveryToken string `json:"deliveryToken"`
+			Messages []struct {
+				ID            string `json:"id"`
+				Body          []byte `json:"body"`
+				DeliveryToken string `json:"deliveryToken"`
+			} `json:"messages"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 			return nil, err
 		}
-		return &delivery{
-			ID:   payload.ID,
-			Body: payload.Body,
-			Ack: func(ctx context.Context) error {
-				type ackRequest struct {
-					MessageID     string `json:"messageId"`
-					QueueID       string `json:"queueId"`
-					DeliveryToken string `json:"deliveryToken"`
-				}
-				return t.postJSON(ctx, "/ack", ackRequest{
-					MessageID:     payload.ID,
-					QueueID:       t.queueID,
-					DeliveryToken: payload.DeliveryToken,
-				}, nil)
-			},
-		}, nil
+		msgs := make([]receivedMsg, 0, len(payload.Messages))
+		for _, m := range payload.Messages {
+			msgs = append(msgs, receivedMsg{ID: m.ID, Body: m.Body, DeliveryToken: m.DeliveryToken})
+		}
+		return msgs, nil
 	case http.StatusNotFound:
 		io.Copy(io.Discard, resp.Body)
 		return nil, errNoMessage
@@ -665,6 +777,26 @@ func (t *kueueTarget) receive(ctx context.Context, wait bool) (*delivery, error)
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("kueue receive returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
+}
+
+func (t *kueueTarget) Cleanup(ctx context.Context) error {
+	t.mu.Lock()
+	pending := t.pendingAcks
+	t.pendingAcks = nil
+	t.msgBuf = nil
+	t.mu.Unlock()
+
+	var err error
+	if len(pending) > 0 {
+		t.mu.Lock()
+		t.pendingAcks = pending
+		err = t.flushAcksLocked(ctx)
+		t.pendingAcks = nil
+		t.mu.Unlock()
+	}
+
+	t.queueID = ""
+	return err
 }
 
 func (t *kueueTarget) postJSON(ctx context.Context, path string, requestBody any, out any) error {

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -804,15 +804,40 @@ func (t *kueueTarget) flushAcks(ctx context.Context, acks []ackEntryBench) error
 		Acks    []ackEntryBench `json:"acks"`
 	}
 
+	type ackResult struct {
+		MessageId string `json:"messageId"`
+		Status    string `json:"status"`
+		Error     string `json:"error,omitempty"`
+	}
+	type batchAckResponse struct {
+		Results []ackResult `json:"results"`
+	}
+
 	req := batchReqBody{
 		QueueId: t.queueID,
 		Acks:    acks,
 	}
 
-	if err := t.postJSON(ctx, "/ack", req, nil); err != nil {
+	var resp batchAckResponse
+	if err := t.postJSON(ctx, "/ack", req, &resp); err != nil {
 		return err
 	}
-	return nil
+
+	// Check per-entry results
+	var firstErr error
+	for _, r := range resp.Results {
+		if r.Status != "ok" {
+			err := fmt.Errorf("ack %s failed: %s", r.MessageId, r.Error)
+			if firstErr == nil {
+				firstErr = err
+			}
+			if debugLog {
+				debugf("batch ack error: %v", err)
+			}
+		}
+	}
+
+	return firstErr
 }
 
 func (t *kueueTarget) receiveBatch(ctx context.Context) ([]receivedMsg, error) {

--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -9,13 +9,16 @@ import (
 )
 
 func TestKueueTargetAckIncludesDeliveryToken(t *testing.T) {
-	type ackRequest struct {
+	type batchAckEntry struct {
 		MessageID     string `json:"messageId"`
-		QueueID       string `json:"queueId"`
 		DeliveryToken string `json:"deliveryToken"`
 	}
+	type batchAckRequest struct {
+		QueueID string          `json:"queueId"`
+		Acks    []batchAckEntry `json:"acks"`
+	}
 
-	ackRequests := make(chan ackRequest, 1)
+	ackRequests := make(chan batchAckRequest, 1)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -26,14 +29,18 @@ func TestKueueTargetAckIncludesDeliveryToken(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusAccepted)
 			if err := json.NewEncoder(w).Encode(map[string]any{
-				"id":            "message-1",
-				"body":          []byte("payload"),
-				"deliveryToken": "token-1",
+				"messages": []any{
+					map[string]any{
+						"id":            "message-1",
+						"body":          []byte("payload"),
+						"deliveryToken": "token-1",
+					},
+				},
 			}); err != nil {
 				t.Errorf("encode receive response: %v", err)
 			}
 		case "/ack":
-			var req ackRequest
+			var req batchAckRequest
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				http.Error(w, "bad ack request", http.StatusBadRequest)
 				return
@@ -51,6 +58,7 @@ func TestKueueTargetAckIncludesDeliveryToken(t *testing.T) {
 
 	target := newKueueTarget(server.URL)
 	target.queueID = "queue-1"
+	target.batchSize = 1
 
 	msg, err := target.Consume(context.Background())
 	if err != nil {
@@ -62,14 +70,17 @@ func TestKueueTargetAckIncludesDeliveryToken(t *testing.T) {
 
 	select {
 	case req := <-ackRequests:
-		if req.MessageID != "message-1" {
-			t.Fatalf("ack message id = %q, want message-1", req.MessageID)
-		}
 		if req.QueueID != "queue-1" {
 			t.Fatalf("ack queue id = %q, want queue-1", req.QueueID)
 		}
-		if req.DeliveryToken != "token-1" {
-			t.Fatalf("ack delivery token = %q, want token-1", req.DeliveryToken)
+		if len(req.Acks) != 1 {
+			t.Fatalf("expected 1 ack entry, got %d", len(req.Acks))
+		}
+		if req.Acks[0].MessageID != "message-1" {
+			t.Fatalf("ack message id = %q, want message-1", req.Acks[0].MessageID)
+		}
+		if req.Acks[0].DeliveryToken != "token-1" {
+			t.Fatalf("ack delivery token = %q, want token-1", req.Acks[0].DeliveryToken)
 		}
 	default:
 		t.Fatal("ack endpoint was not called")

--- a/main.go
+++ b/main.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"net/http"
+	"strconv"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -374,6 +376,16 @@ type AckRequest struct {
 	DeliveryToken string `json:"deliveryToken"`
 }
 
+type AckEntry struct {
+	MessageId     string `json:"messageId"`
+	DeliveryToken string `json:"deliveryToken"`
+}
+
+type BatchAckRequest struct {
+	QueueId string     `json:"queueId"`
+	Acks    []AckEntry `json:"acks"`
+}
+
 func create(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Only POST allowed", http.StatusMethodNotAllowed)
@@ -638,6 +650,96 @@ func claimNextReadyMessage(queueId string) (*Message, error) {
 	return claimed, nil
 }
 
+func claimReadyMessages(queueId string, max int) ([]Message, error) {
+	var claimed []Message
+	err := Db.Update(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		prefix := readyPrefix(queueId)
+		opts.Prefix = prefix
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Rewind(); it.Valid() && len(claimed) < max; it.Next() {
+			item := it.Item()
+			rKey := item.KeyCopy(nil)
+			readySeq, msgID, err := readyPartsFromKey(rKey, prefix)
+			if err != nil {
+				return fmt.Errorf("parse ready key: %w", err)
+			}
+
+			msgKey := messageKeyBytes(queueId, readySeq, msgID)
+			msgItem, err := txn.Get(msgKey)
+			if err != nil {
+				if err == badger.ErrKeyNotFound {
+					var originalSeq uint64
+					valueErr := item.Value(func(v []byte) error {
+						parsedSeq, parseErr := parseReadyValue(v)
+						if parseErr != nil {
+							return parseErr
+						}
+						originalSeq = parsedSeq
+						return nil
+					})
+					if valueErr != nil {
+						return fmt.Errorf("parse ready value: %w", valueErr)
+					}
+					msgKey = messageKeyBytes(queueId, originalSeq, msgID)
+					msgItem, err = txn.Get(msgKey)
+					if err == badger.ErrKeyNotFound {
+						if err := txn.Delete(rKey); err != nil {
+							return fmt.Errorf("delete stale ready pointer %x: %w", rKey, err)
+						}
+						continue
+					}
+				}
+				if err != nil {
+					return fmt.Errorf("get message for ready key: %w", err)
+				}
+			}
+
+			var msg Message
+			if err := msgItem.Value(func(v []byte) error {
+				return json.Unmarshal(v, &msg)
+			}); err != nil {
+				return fmt.Errorf("unmarshal message: %w", err)
+			}
+
+			if msg.State != StateReady {
+				txn.Delete(rKey)
+				continue
+			}
+
+			if err := txn.Delete(rKey); err != nil {
+				return fmt.Errorf("delete ready key: %w", err)
+			}
+
+			msg.State = StateInFlight
+			msg.VisibilityDeadline = time.Now().Add(30 * time.Second)
+			msg.DeliveryCount++
+			msg.DeliveryAttemptID = uuid.NewString()
+
+			updated, err := json.Marshal(msg)
+			if err != nil {
+				return fmt.Errorf("marshal claimed message: %w", err)
+			}
+			if err := txn.Set(msgKey, updated); err != nil {
+				return fmt.Errorf("set claimed message: %w", err)
+			}
+
+			claimed = append(claimed, msg)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(claimed) == 0 {
+		return nil, ErrNoReadyMessages
+	}
+	return claimed, nil
+}
+
 func receive(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Only GET allowed", http.StatusMethodNotAllowed)
@@ -665,65 +767,147 @@ func receive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var msg *Message
-	var claimErr error
+	max := 1
+	if maxStr := params.Get("max"); maxStr != "" {
+		parsed, parseErr := strconv.Atoi(maxStr)
+		if parseErr != nil || parsed < 1 || parsed > 100 {
+			http.Error(w, "max must be an integer between 1 and 100", http.StatusBadRequest)
+			return
+		}
+		max = parsed
+	}
 
-	if wait := params.Get("wait"); wait == "true" {
-		msg, claimErr = claimNextReadyMessage(id)
+	if max == 1 {
+		var msg *Message
+		var claimErr error
+
+		if wait := params.Get("wait"); wait == "true" {
+			msg, claimErr = claimNextReadyMessage(id)
+			if claimErr != nil && claimErr != ErrNoReadyMessages {
+				http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
+				return
+			}
+			if claimErr == ErrNoReadyMessages {
+				readyCh := queueReadyChan(id)
+				timer := time.NewTimer(30 * time.Second)
+				defer timer.Stop()
+			waitLoop:
+				for {
+					msg, claimErr = claimNextReadyMessage(id)
+					if claimErr == nil {
+						break
+					}
+					if claimErr != nil && claimErr != ErrNoReadyMessages {
+						http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
+						return
+					}
+					select {
+					case <-readyCh:
+						readyCh = queueReadyChan(id)
+						continue
+					case <-timer.C:
+						break waitLoop
+					case <-r.Context().Done():
+						return
+					}
+				}
+			}
+		} else {
+			msg, claimErr = claimNextReadyMessage(id)
+		}
+
 		if claimErr != nil && claimErr != ErrNoReadyMessages {
 			http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
 			return
 		}
-		if claimErr == ErrNoReadyMessages {
+		if claimErr == ErrNoReadyMessages || msg == nil {
+			http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
+			return
+		}
+
+		m := getOrCreateMetrics(id)
+		m.totalReceived.Add(1)
+		m.readyCount.Add(-1)
+		m.inFlightCount.Add(1)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":            msg.ID,
+			"body":          msg.Body,
+			"state":         StateInFlight,
+			"deliveryToken": msg.DeliveryAttemptID,
+		})
+		return
+	}
+
+	// batch receive (max > 1)
+	msgs, claimErr := claimReadyMessages(id, max)
+	if claimErr != nil && claimErr != ErrNoReadyMessages {
+		http.Error(w, "Error retrieving messages: "+claimErr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if wait := params.Get("wait"); wait == "true" {
+		if len(msgs) == 0 {
 			readyCh := queueReadyChan(id)
 			timer := time.NewTimer(30 * time.Second)
 			defer timer.Stop()
-		waitLoop:
+		waitLoopBatch:
 			for {
-				msg, claimErr = claimNextReadyMessage(id)
-				if claimErr == nil {
-					break
-				}
+				msgs, claimErr = claimReadyMessages(id, max)
 				if claimErr != nil && claimErr != ErrNoReadyMessages {
-					http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
+					http.Error(w, "Error retrieving messages: "+claimErr.Error(), http.StatusInternalServerError)
 					return
+				}
+				if len(msgs) > 0 {
+					break
 				}
 				select {
 				case <-readyCh:
 					readyCh = queueReadyChan(id)
 					continue
 				case <-timer.C:
-					break waitLoop
+					break waitLoopBatch
 				case <-r.Context().Done():
 					return
 				}
 			}
 		}
-	} else {
-		msg, claimErr = claimNextReadyMessage(id)
 	}
 
-	if claimErr != nil && claimErr != ErrNoReadyMessages {
-		http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
-		return
-	}
-	if claimErr == ErrNoReadyMessages || msg == nil {
+	if len(msgs) == 0 {
 		http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
 		return
 	}
 
+	type batchMessage struct {
+		ID            string       `json:"id"`
+		Body          []byte       `json:"body"`
+		State         MessageState `json:"state"`
+		DeliveryToken string       `json:"deliveryToken"`
+	}
+	batch := make([]batchMessage, 0, len(msgs))
+	for _, msg := range msgs {
+		batch = append(batch, batchMessage{
+			ID:            msg.ID,
+			Body:          msg.Body,
+			State:         StateInFlight,
+			DeliveryToken: msg.DeliveryAttemptID,
+		})
+	}
+
 	m := getOrCreateMetrics(id)
-	m.totalReceived.Add(1)
-	m.readyCount.Add(-1)
-	m.inFlightCount.Add(1)
+	for range msgs {
+		m.totalReceived.Add(1)
+		m.readyCount.Add(-1)
+		m.inFlightCount.Add(1)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(map[string]any{
-		"id":            msg.ID,
-		"body":          msg.Body,
-		"state":         StateInFlight,
-		"deliveryToken": msg.DeliveryAttemptID,
+		"messages": batch,
 	})
 }
 
@@ -732,9 +916,23 @@ func ack(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Only POST allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	var ackReq AckRequest
-	err := json.NewDecoder(r.Body).Decode(&ackReq)
+
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		return
+	}
+
+	// Try batch ack first
+	var batchReq BatchAckRequest
+	if json.Unmarshal(body, &batchReq) == nil && len(batchReq.Acks) > 0 {
+		handleBatchAck(w, batchReq)
+		return
+	}
+
+	// Fall back to single ack
+	var ackReq AckRequest
+	if err := json.Unmarshal(body, &ackReq); err != nil {
 		http.Error(w, "Bad Request: "+err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -786,7 +984,71 @@ func ack(w http.ResponseWriter, r *http.Request) {
 
 	m := getOrCreateMetrics(ackReq.QueueId)
 	m.recordAck()
+}
 
+func handleBatchAck(w http.ResponseWriter, batchReq BatchAckRequest) {
+	if batchReq.QueueId == "" {
+		http.Error(w, "queueId is required", http.StatusBadRequest)
+		return
+	}
+
+	type batchAckResult struct {
+		MessageId string `json:"messageId"`
+		Status    string `json:"status"`
+		Error     string `json:"error,omitempty"`
+	}
+
+	results := make([]batchAckResult, len(batchReq.Acks))
+
+	err := Db.Update(func(txn *badger.Txn) error {
+		if _, err := txn.Get([]byte(batchReq.QueueId)); err != nil {
+			return err
+		}
+
+		for i, entry := range batchReq.Acks {
+			results[i].MessageId = entry.MessageId
+
+			key, msg, err := findMessageRecord(txn, batchReq.QueueId, entry.MessageId)
+			if err != nil {
+				results[i].Status = "error"
+				results[i].Error = fmt.Sprintf("message not found: %v", err)
+				continue
+			}
+			if msg.DeliveryAttemptID != entry.DeliveryToken {
+				results[i].Status = "error"
+				results[i].Error = fmt.Sprintf("delivery token mismatch: expected %q, got %q", msg.DeliveryAttemptID, entry.DeliveryToken)
+				continue
+			}
+			if err := txn.Delete(key); err != nil {
+				results[i].Status = "error"
+				results[i].Error = fmt.Sprintf("delete failed: %v", err)
+				continue
+			}
+			results[i].Status = "ok"
+		}
+		return nil
+	})
+	if err != nil {
+		if err == badger.ErrKeyNotFound {
+			http.Error(w, "Queue not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "Failed to acknowledge: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	m := getOrCreateMetrics(batchReq.QueueId)
+	for _, res := range results {
+		if res.Status == "ok" {
+			m.recordAck()
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(map[string]any{
+		"results": results,
+	})
 }
 
 func nack(w http.ResponseWriter, r *http.Request) {

--- a/main_test.go
+++ b/main_test.go
@@ -754,3 +754,314 @@ func receiveBenchMessage(b testing.TB, queueID string) receiveResponse {
 	json.NewDecoder(rec.Body).Decode(&resp)
 	return resp
 }
+
+type batchReceiveResponse struct {
+	Messages []struct {
+		ID            string       `json:"id"`
+		Body          []byte       `json:"body"`
+		State         MessageState `json:"state"`
+		DeliveryToken string       `json:"deliveryToken"`
+	} `json:"messages"`
+}
+
+type batchAckResult struct {
+	MessageId string `json:"messageId"`
+	Status    string `json:"status"`
+	Error     string `json:"error,omitempty"`
+}
+
+type batchAckResponse struct {
+	Results []batchAckResult `json:"results"`
+}
+
+func TestBatchReceiveReturnsMultipleMessages(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "batch-queue")
+
+	publishTestMessage(t, queueID, []byte("first"))
+	publishTestMessage(t, queueID, []byte("second"))
+	publishTestMessage(t, queueID, []byte("third"))
+
+	req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID+"&max=5", nil)
+	recorder := httptest.NewRecorder()
+	receive(recorder, req)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("batch receive status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	resp := decodeResponse[batchReceiveResponse](t, recorder)
+	if len(resp.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(resp.Messages))
+	}
+	if string(resp.Messages[0].Body) != "first" {
+		t.Fatalf("first body = %q, want first", string(resp.Messages[0].Body))
+	}
+	if string(resp.Messages[1].Body) != "second" {
+		t.Fatalf("second body = %q, want second", string(resp.Messages[1].Body))
+	}
+	if string(resp.Messages[2].Body) != "third" {
+		t.Fatalf("third body = %q, want third", string(resp.Messages[2].Body))
+	}
+	for _, m := range resp.Messages {
+		if m.State != StateInFlight {
+			t.Fatalf("message %s state = %s, want in_flight", m.ID, m.State)
+		}
+		if m.DeliveryToken == "" {
+			t.Fatalf("message %s has empty delivery token", m.ID)
+		}
+	}
+}
+
+func TestBatchReceiveRespectsMaxLimit(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "max-limit-queue")
+
+	for i := 0; i < 10; i++ {
+		publishTestMessage(t, queueID, []byte("msg"))
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID+"&max=3", nil)
+	recorder := httptest.NewRecorder()
+	receive(recorder, req)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("batch receive status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	resp := decodeResponse[batchReceiveResponse](t, recorder)
+	if len(resp.Messages) != 3 {
+		t.Fatalf("expected 3 messages (max=3), got %d", len(resp.Messages))
+	}
+}
+
+func TestBatchReceiveMaxParamValidation(t *testing.T) {
+	tests := []struct {
+		max  string
+		code int
+	}{
+		{max: "0", code: http.StatusBadRequest},
+		{max: "-1", code: http.StatusBadRequest},
+		{max: "101", code: http.StatusBadRequest},
+		{max: "abc", code: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run("max="+tt.max, func(t *testing.T) {
+			setupTestDB(t)
+			queueID := createTestQueue(t, "validation-queue")
+			req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID+"&max="+tt.max, nil)
+			recorder := httptest.NewRecorder()
+			receive(recorder, req)
+			if recorder.Code != tt.code {
+				t.Fatalf("expected status %d, got %d: %s", tt.code, recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestBatchAckMultipleMessages(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "batch-ack-queue")
+
+	msg1ID := publishTestMessage(t, queueID, []byte("one"))
+	msg2ID := publishTestMessage(t, queueID, []byte("two"))
+	msg3ID := publishTestMessage(t, queueID, []byte("three"))
+
+	batchResp := func() batchReceiveResponse {
+		req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID+"&max=10", nil)
+		rec := httptest.NewRecorder()
+		receive(rec, req)
+		return decodeResponse[batchReceiveResponse](t, rec)
+	}()
+
+	if len(batchResp.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(batchResp.Messages))
+	}
+
+	// Batch ack all three
+	ackBody, _ := json.Marshal(BatchAckRequest{
+		QueueId: queueID,
+		Acks: []AckEntry{
+			{MessageId: msg1ID, DeliveryToken: batchResp.Messages[0].DeliveryToken},
+			{MessageId: msg2ID, DeliveryToken: batchResp.Messages[1].DeliveryToken},
+			{MessageId: msg3ID, DeliveryToken: batchResp.Messages[2].DeliveryToken},
+		},
+	})
+
+	ackReq := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(ackBody))
+	ackRecorder := httptest.NewRecorder()
+	ack(ackRecorder, ackReq)
+
+	if ackRecorder.Code != http.StatusAccepted {
+		t.Fatalf("batch ack status = %d, body = %s", ackRecorder.Code, ackRecorder.Body.String())
+	}
+
+	ackResp := decodeResponse[batchAckResponse](t, ackRecorder)
+	if len(ackResp.Results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(ackResp.Results))
+	}
+	for i, res := range ackResp.Results {
+		if res.Status != "ok" {
+			t.Fatalf("ack[%d] status = %s, error = %s", i, res.Status, res.Error)
+		}
+	}
+
+	// Verify all messages are deleted
+	for _, msgID := range []string{msg1ID, msg2ID, msg3ID} {
+		err := Db.View(func(txn *badger.Txn) error {
+			key, _, err := findMessageRecord(txn, queueID, msgID)
+			if err != nil {
+				return err
+			}
+			t.Fatalf("expected message %s to be deleted, found at %x", msgID, key)
+			return nil
+		})
+		if err == nil {
+			t.Fatalf("message %s was not deleted", msgID)
+		}
+	}
+}
+
+func TestBatchAckReportsPartialErrors(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "batch-ack-err-queue")
+
+	msg1ID := publishTestMessage(t, queueID, []byte("one"))
+	msg2ID := publishTestMessage(t, queueID, []byte("two"))
+
+	batchResp := func() batchReceiveResponse {
+		req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID+"&max=10", nil)
+		rec := httptest.NewRecorder()
+		receive(rec, req)
+		return decodeResponse[batchReceiveResponse](t, rec)
+	}()
+
+	if len(batchResp.Messages) < 2 {
+		t.Fatalf("expected at least 2 messages, got %d", len(batchResp.Messages))
+	}
+
+	// Ack: msg1 with correct token, msg2 with wrong token
+	ackBody, _ := json.Marshal(BatchAckRequest{
+		QueueId: queueID,
+		Acks: []AckEntry{
+			{MessageId: msg1ID, DeliveryToken: batchResp.Messages[0].DeliveryToken},
+			{MessageId: msg2ID, DeliveryToken: "wrong-token"},
+		},
+	})
+
+	ackReq := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(ackBody))
+	ackRecorder := httptest.NewRecorder()
+	ack(ackRecorder, ackReq)
+
+	if ackRecorder.Code != http.StatusAccepted {
+		t.Fatalf("batch ack status = %d, body = %s", ackRecorder.Code, ackRecorder.Body.String())
+	}
+
+	ackResp := decodeResponse[batchAckResponse](t, ackRecorder)
+	if len(ackResp.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(ackResp.Results))
+	}
+
+	if r0 := ackResp.Results[0]; r0.Status != "ok" {
+		t.Fatalf("ack[0] expected ok, got %s: %s", r0.Status, r0.Error)
+	}
+	if r1 := ackResp.Results[1]; r1.Status != "error" {
+		t.Fatalf("ack[1] expected error, got %s", r1.Status)
+	}
+
+	// msg1 should be deleted, msg2 should still exist
+	var msg2Exists bool
+	err := Db.View(func(txn *badger.Txn) error {
+		_, _, err := findMessageRecord(txn, queueID, msg2ID)
+		if err == badger.ErrKeyNotFound {
+			msg2Exists = false
+			return nil
+		}
+		msg2Exists = true
+		return err
+	})
+	if err != nil {
+		t.Fatalf("check msg2: %v", err)
+	}
+	if !msg2Exists {
+		t.Fatal("msg2 should not have been deleted")
+	}
+}
+
+func TestBatchReceiveFollowsFIFOOrder(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "batch-fifo-queue")
+
+	count := 20
+	for i := 0; i < count; i++ {
+		publishTestMessage(t, queueID, []byte(fmt.Sprintf("msg-%d", i)))
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID+"&max=10", nil)
+	recorder := httptest.NewRecorder()
+	receive(recorder, req)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("batch receive status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	resp := decodeResponse[batchReceiveResponse](t, recorder)
+	if len(resp.Messages) != 10 {
+		t.Fatalf("expected 10 messages, got %d", len(resp.Messages))
+	}
+
+	for i, m := range resp.Messages {
+		expected := fmt.Sprintf("msg-%d", i)
+		if string(m.Body) != expected {
+			t.Fatalf("message[%d] body = %q, want %q", i, string(m.Body), expected)
+		}
+	}
+}
+
+func TestBatchReceiveLongPollWithWait(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "batch-longpoll")
+
+	req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID+"&max=5&wait=true", nil)
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		receive(recorder, req)
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	for i := 0; i < 3; i++ {
+		publishTestMessage(t, queueID, []byte(fmt.Sprintf("batch-%d", i)))
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("batch long-poll receive did not complete")
+	}
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("receive status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	resp := decodeResponse[batchReceiveResponse](t, recorder)
+	if len(resp.Messages) == 0 {
+		t.Fatal("expected at least 1 message from long poll")
+	}
+	if len(resp.Messages) > 3 {
+		t.Fatalf("expected at most 3 messages, got %d", len(resp.Messages))
+	}
+	// FIFO: first published should be first received
+	if string(resp.Messages[0].Body) != "batch-0" {
+		t.Fatalf("first message body = %q, want batch-0", string(resp.Messages[0].Body))
+	}
+}


### PR DESCRIPTION
## Summary
- **Batch receive**: GET /receive?id=X&max=N returns up to N messages in one HTTP response, with long-polling support when wait=true
- **Batch ack**: POST /ack accepts array of {messageId, deliveryToken} entries, with per-entry status reporting for partial failures
- **Leveled benchmark**: Two honest sections -- End-to-end (kueue batch=10 vs RabbitMQ prefetch=200) and Apples-to-apples (batch=1 vs prefetch=1), each with clear notes about what they measure

## Server changes (main.go)
- claimReadyMessages(queueId, max) -- atomic batch claim in a single BadgerDB transaction, reusing stale-pointer cleanup logic
- receive handler parses max param (1-100), returns {"messages": [...]} for max>1, preserves single-message fallback
- /ack handler detects batch format via acks array; single-message format unchanged
- handleBatchAck processes multiple acks in one transaction with per-entry error reporting

## Benchmark changes (cmd/bench/main.go)
- kueueTarget uses batch receive with internal message buffer and deferred batch ack flushing
- workloadConfig.KueueBatchSize controls batch size
- main() runs two sections: End-to-end and Apples-to-apples with clear notes

## Tests
- Batch receive: multiple messages, max limit, FIFO ordering, param validation
- Batch ack: multi-message success, partial failure with wrong delivery token
- Batch long-poll with wait=true
- Updated benchmark test for new batch API shapes

## Files changed
| File | Change |
|------|--------|
| main.go | +batch receive handler, +batch ack handler, +claimReadyMessages |
| main_test.go | +batch receive/ack tests (311 lines) |
| cmd/bench/main.go | +batch consume/ack target, +dual-section benchmark |
| cmd/bench/main_test.go | +updated test for batch API |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Receive now supports fetching multiple messages via a max parameter (1–100) and returns messages as an array.
  * Ack now accepts batch acknowledgements for confirming multiple messages in one request.
  * Benchmark tool: results split into labeled sections and JSON output includes a sections[] structure.

* **Improvements**
  * Benchmark: added debug-gated logging, configurable batch size for queue operations, and an “apples-to-apples” section with forced prefetch/batch settings.
  * Receive/ack endpoints use batched semantics and long-polling for batched retrieval.

* **Tests**
  * Added tests covering batched receive and batch ack behaviors, including partial-failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->