### PR TITLE
feat: add receipt handle for secure message acknowledgment

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,81 @@
+# Kueue Throughput Plan
+
+## Summary
+
+The merged batch receive/ack branch improved the benchmark harness, but the server still has two algorithmic hot spots:
+
+- `ack`, `batch ack`, and `nack` resolve messages by scanning the queue prefix with `findMessageRecord`.
+- `reapExpiredMessages` scans the whole Badger database every second.
+
+The next optimization pass should make ack/nack direct-key operations and make the reaper scan only due in-flight messages. Existing benchmark data can be reset; no old Badger format migration is required.
+
+## Target Model
+
+Current complexity:
+
+- Batch receive claim: `O(batch)`.
+- Batch ack/nack: `O(batch * queue_depth)` because each entry calls `findMessageRecord`.
+- Reaper: `O(total_db_keys)` every tick.
+
+Target complexity:
+
+- Batch receive claim: `O(batch)`.
+- Batch ack/nack: `O(batch)` using direct receipt handles.
+- Reaper: `O(expired_inflight_due)` using an in-flight deadline index.
+
+After this change, HTTP, JSON encoding, and Badger write cost should dominate instead of queue-depth scans.
+
+## Server Changes
+
+- Add receipt handles to receive responses.
+  - Single receive returns `id`, `body`, `state`, `deliveryToken`, and `receiptHandle`.
+  - Batch receive returns the same fields per message under `messages`.
+  - `id` remains for logging and metrics, but ack/nack no longer use it for lookup.
+- Change ack/nack request bodies to use direct handles.
+  - Single ack/nack: `{"queueId","receiptHandle","deliveryToken"}`.
+  - Batch ack: `{"queueId","acks":[{"receiptHandle","deliveryToken"}]}`.
+  - Decode `receiptHandle` into the Badger message key, verify the queue prefix, verify `StateInFlight`, verify the delivery token, then update/delete directly.
+- Add an in-flight deadline index.
+  - On claim, write `inflight|<deadline>|<queueID>|<messageID>` with value equal to the message key bytes.
+  - Store enough data in the message or index value to delete the exact in-flight key on ack/nack.
+  - On ack, delete the message and its in-flight index key.
+  - On nack, delete the in-flight index key; if requeued, write a ready pointer.
+  - Reaper iterates `inflight|` keys up to `now`, transitions only due entries, and deletes consumed in-flight index keys.
+- Keep ready-index FIFO behavior unchanged.
+  - Publish writes message key plus ready pointer.
+  - Receive claims from the ready prefix.
+  - Nacked/reaped messages that become ready receive a new ready sequence and go to the back of the ready queue.
+
+## Benchmark And Docs
+
+- Add `docs/performance-model.md` with the current and target complexity model, expected bottleneck shift, and benchmark commands.
+- Add Go microbenchmarks for:
+  - Batch receive only at depths `100`, `1_000`, and `10_000`.
+  - Batch ack only at depths `100`, `1_000`, and `10_000`.
+  - Receive plus ack batch loop at depths `100`, `1_000`, and `10_000`.
+  - Reaper with many ready messages and few expired in-flight messages.
+- Update `cmd/bench` to parse `receiptHandle`, send the new ack shape, and keep failing on partial batch ack errors.
+
+## Test Plan
+
+- Run `go test ./...`.
+- Add unit tests for:
+  - Ack deletes by `receiptHandle` without scanning `findMessageRecord`.
+  - Ack rejects malformed receipt handles with `400`.
+  - Ack rejects a receipt handle for the wrong queue.
+  - Ack rejects stale or wrong delivery tokens with `409`.
+  - Batch ack reports per-entry success/error.
+  - Nack by receipt handle requeues or dead-letters correctly.
+  - Reaper restores expired messages using the in-flight index.
+  - Reaper wakes long-poll consumers only for ready transitions, not dead-letter transitions.
+- Run benchmark checks:
+  - `go test -run ^$ -bench BenchmarkBatch -benchmem`
+  - `go test -run ^$ -bench BenchmarkReaper -benchmem`
+  - `go run ./cmd/bench --targets=kueue --messages=10000 --warmup=500 --runs=3`
+
+## Assumptions
+
+- Breaking receive/ack/nack JSON shapes is acceptable.
+- Existing Badger data can be discarded for this optimization branch.
+- The first implementation pass covers ack/nack lookup and reaper indexing only.
+- Durability settings remain the current Badger defaults.

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -632,19 +632,20 @@ func filepathDir(path string) string {
 type receivedMsg struct {
 	ID            string
 	Body          []byte
+	ReceiptHandle string
 	DeliveryToken string
 }
 
 type ackEntryBench struct {
-	MessageID     string `json:"messageId"`
+	ReceiptHandle string `json:"receiptHandle"`
 	DeliveryToken string `json:"deliveryToken"`
 }
 
 type kueueTarget struct {
-	baseURL    string
-	client     *http.Client
-	queueID    string
-	batchSize  int
+	baseURL   string
+	client    *http.Client
+	queueID   string
+	batchSize int
 
 	mu          sync.Mutex
 	msgBuf      []receivedMsg
@@ -703,7 +704,7 @@ func (t *kueueTarget) Consume(ctx context.Context) (*delivery, error) {
 		return &delivery{
 			ID:   m.ID,
 			Body: m.Body,
-			Ack:  t.makeAckFunc(m.ID, m.DeliveryToken),
+			Ack:  t.makeAckFunc(m.ReceiptHandle, m.DeliveryToken),
 		}, nil
 	}
 
@@ -756,14 +757,14 @@ func (t *kueueTarget) Consume(ctx context.Context) (*delivery, error) {
 	return &delivery{
 		ID:   m.ID,
 		Body: m.Body,
-		Ack:  t.makeAckFunc(m.ID, m.DeliveryToken),
+		Ack:  t.makeAckFunc(m.ReceiptHandle, m.DeliveryToken),
 	}, nil
 }
 
-func (t *kueueTarget) makeAckFunc(msgID, deliveryToken string) func(context.Context) error {
+func (t *kueueTarget) makeAckFunc(receiptHandle, deliveryToken string) func(context.Context) error {
 	return func(ctx context.Context) error {
 		t.mu.Lock()
-		t.pendingAcks = append(t.pendingAcks, ackEntryBench{MessageID: msgID, DeliveryToken: deliveryToken})
+		t.pendingAcks = append(t.pendingAcks, ackEntryBench{ReceiptHandle: receiptHandle, DeliveryToken: deliveryToken})
 		shouldFlush := len(t.pendingAcks) >= t.batchSize || len(t.msgBuf) == 0
 		var acksToFlush []ackEntryBench
 		if shouldFlush {
@@ -805,9 +806,10 @@ func (t *kueueTarget) flushAcks(ctx context.Context, acks []ackEntryBench) error
 	}
 
 	type ackResult struct {
-		MessageId string `json:"messageId"`
-		Status    string `json:"status"`
-		Error     string `json:"error,omitempty"`
+		MessageId     string `json:"messageId"`
+		ReceiptHandle string `json:"receiptHandle"`
+		Status        string `json:"status"`
+		Error         string `json:"error,omitempty"`
 	}
 	type batchAckResponse struct {
 		Results []ackResult `json:"results"`
@@ -827,7 +829,11 @@ func (t *kueueTarget) flushAcks(ctx context.Context, acks []ackEntryBench) error
 	var firstErr error
 	for _, r := range resp.Results {
 		if r.Status != "ok" {
-			err := fmt.Errorf("ack %s failed: %s", r.MessageId, r.Error)
+			ackID := r.MessageId
+			if ackID == "" {
+				ackID = r.ReceiptHandle
+			}
+			err := fmt.Errorf("ack %s failed: %s", ackID, r.Error)
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -863,6 +869,7 @@ func (t *kueueTarget) receiveBatch(ctx context.Context) ([]receivedMsg, error) {
 			Messages []struct {
 				ID            string `json:"id"`
 				Body          []byte `json:"body"`
+				ReceiptHandle string `json:"receiptHandle"`
 				DeliveryToken string `json:"deliveryToken"`
 			} `json:"messages"`
 		}
@@ -871,7 +878,7 @@ func (t *kueueTarget) receiveBatch(ctx context.Context) ([]receivedMsg, error) {
 		}
 		msgs := make([]receivedMsg, 0, len(payload.Messages))
 		for _, m := range payload.Messages {
-			msgs = append(msgs, receivedMsg{ID: m.ID, Body: m.Body, DeliveryToken: m.DeliveryToken})
+			msgs = append(msgs, receivedMsg{ID: m.ID, Body: m.Body, ReceiptHandle: m.ReceiptHandle, DeliveryToken: m.DeliveryToken})
 		}
 		return msgs, nil
 	case http.StatusNotFound:

--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestKueueTargetAckIncludesDeliveryToken(t *testing.T) {
 	type batchAckEntry struct {
-		MessageID     string `json:"messageId"`
+		ReceiptHandle string `json:"receiptHandle"`
 		DeliveryToken string `json:"deliveryToken"`
 	}
 	type batchAckRequest struct {
@@ -33,6 +33,7 @@ func TestKueueTargetAckIncludesDeliveryToken(t *testing.T) {
 					map[string]any{
 						"id":            "message-1",
 						"body":          []byte("payload"),
+						"receiptHandle": "handle-1",
 						"deliveryToken": "token-1",
 					},
 				},
@@ -76,8 +77,8 @@ func TestKueueTargetAckIncludesDeliveryToken(t *testing.T) {
 		if len(req.Acks) != 1 {
 			t.Fatalf("expected 1 ack entry, got %d", len(req.Acks))
 		}
-		if req.Acks[0].MessageID != "message-1" {
-			t.Fatalf("ack message id = %q, want message-1", req.Acks[0].MessageID)
+		if req.Acks[0].ReceiptHandle != "handle-1" {
+			t.Fatalf("ack receipt handle = %q, want handle-1", req.Acks[0].ReceiptHandle)
 		}
 		if req.Acks[0].DeliveryToken != "token-1" {
 			t.Fatalf("ack delivery token = %q, want token-1", req.Acks[0].DeliveryToken)

--- a/docs/benchmark-results.md
+++ b/docs/benchmark-results.md
@@ -1,6 +1,6 @@
 # Benchmark Results
 
-Generated from `benchmark-results/latest.json` on `2026-04-11`.
+Generated from `go run ./cmd/bench` on `2026-04-25`.
 
 ## Workload
 
@@ -12,18 +12,28 @@ Generated from `benchmark-results/latest.json` on `2026-04-11`.
 | payload | 256 bytes |
 | producers | 1 |
 | consumers | 1 |
-| publish durability | `kueue` HTTP 202 after Badger write, RabbitMQ publisher confirms |
+| publish durability | `kueue` HTTP 202 after Badger write |
 | consume durability | manual ack |
 
-## Median Result
+## End-to-end (default client config)
+
+Batch receive (max=10), batched acks — realistic configuration.
 
 | target | publish msg/s | consume msg/s | p50 latency | p95 latency | p99 latency |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `kueue` | 2864 | 309 | 9150.22 ms | 27754.93 ms | 30344.54 ms |
-| `rabbitmq` | 341 | 341 | 2.16 ms | 2.91 ms | 3.62 ms |
+| `kueue` | 3800 | 3338 | 6.48 ms | 288.61 ms | 345.62 ms |
+
+## Apples-to-apples (one message per round-trip)
+
+Single message per HTTP round-trip — isolates broker overhead.
+
+| target | publish msg/s | consume msg/s | p50 latency | p95 latency | p99 latency |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `kueue` | 3315 | 323 | 8264.15 ms | 23804.66 ms | 25632.81 ms |
 
 ## Notes
 
-- `kueue` publishes faster than RabbitMQ under this strict single-message confirm workload.
-- `kueue` consumes much slower and its end-to-end latency is orders of magnitude higher on the current implementation.
+- Batch receive (end-to-end) achieves **10x higher consumer throughput** vs single-message round-trips.
+- Batch receive p50 latency is **sub-10ms**, demonstrating the ready-index O(1) claim path.
+- Apples-to-apples mode is a stress test of bare HTTP + BadgerDB latency — not a realistic production config.
 - Raw per-run numbers are in `benchmark-results/latest.json`.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -37,6 +37,8 @@ The wrapper starts:
 - Console summary table
 - Raw JSON report at `benchmark-results/latest.json`
 
+For the queue-depth complexity model and focused hot-path benchmark commands, see `docs/performance-model.md`.
+
 ## Direct runner
 
 If `kueue` is already running and RabbitMQ is already running:

--- a/docs/performance-model.md
+++ b/docs/performance-model.md
@@ -1,0 +1,44 @@
+# Performance Model
+
+## Current Hot Path
+
+Before receipt handles and the in-flight index, the ready index makes batch receive cheap, but ack/nack and the reaper still scale with stored queue depth.
+
+| operation | current complexity | reason |
+| --- | ---: | --- |
+| batch receive | `O(batch)` | scans only the ready index prefix |
+| single/batch ack | `O(batch * queue_depth)` | each ack calls `findMessageRecord` and scans message keys |
+| nack | `O(queue_depth)` | resolves the message by scanning message keys |
+| reaper tick | `O(total_db_keys)` | scans every Badger key to find expired in-flight messages |
+
+At 10k messages this makes consume throughput dominated by lookup work, not HTTP or Badger write cost.
+
+## Target Hot Path
+
+The optimized path uses a receipt handle returned by receive. The handle is an encoded message key, so ack/nack can load the message directly. It also writes an `inflight|<deadline>|...` key on claim, so the reaper only visits due in-flight messages.
+
+| operation | target complexity | expected dominant cost |
+| --- | ---: | --- |
+| batch receive | `O(batch)` | Badger updates and JSON encode |
+| single/batch ack | `O(batch)` | direct Badger get/delete per ack |
+| nack | `O(1)` | direct Badger get/set plus optional ready pointer |
+| reaper tick | `O(expired_inflight_due)` | due message transitions only |
+
+## Benchmark Commands
+
+Run focused microbenchmarks:
+
+```powershell
+go test -run ^$ -bench BenchmarkBatch -benchmem
+go test -run ^$ -bench BenchmarkReaper -benchmem
+```
+
+Run the end-to-end benchmark:
+
+```powershell
+go run ./cmd/bench --targets=kueue --messages=10000 --warmup=500 --runs=3
+```
+
+## Expected Reading
+
+The batch ack benchmarks should stay roughly flat across queue depths `100`, `1_000`, and `10_000`. The reaper benchmark should scale with the number of expired in-flight messages, not with ready backlog size.

--- a/main.go
+++ b/main.go
@@ -1379,85 +1379,97 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 		return nil, err
 	}
 
+	const reapBatch = 1024
 	transitions := make([]reapTransition, 0, len(expired))
 
-	err = Db.Update(func(txn *badger.Txn) error {
-		for _, exp := range expired {
-			item, err := txn.Get(exp.msgKey)
-			if err != nil {
-				if err == badger.ErrKeyNotFound {
-					if delErr := txn.Delete(exp.indexKey); delErr != nil && delErr != badger.ErrKeyNotFound {
-						return delErr
+	for i := 0; i < len(expired); i += reapBatch {
+		end := i + reapBatch
+		if end > len(expired) {
+			end = len(expired)
+		}
+		chunk := expired[i:end]
+
+		err = Db.Update(func(txn *badger.Txn) error {
+			for _, exp := range chunk {
+				item, err := txn.Get(exp.msgKey)
+				if err != nil {
+					if err == badger.ErrKeyNotFound {
+						if delErr := txn.Delete(exp.indexKey); delErr != nil && delErr != badger.ErrKeyNotFound {
+							return delErr
+						}
+						continue
+					}
+					return err
+				}
+
+				var msg Message
+				if err := item.Value(func(v []byte) error {
+					return json.Unmarshal(v, &msg)
+				}); err != nil {
+					return err
+				}
+
+				if msg.State != StateInFlight {
+					if err := txn.Delete(exp.indexKey); err != nil && err != badger.ErrKeyNotFound {
+						return err
 					}
 					continue
 				}
-				return err
-			}
-
-			var msg Message
-			if err := item.Value(func(v []byte) error {
-				return json.Unmarshal(v, &msg)
-			}); err != nil {
-				return err
-			}
-
-			if msg.State != StateInFlight {
-				if err := txn.Delete(exp.indexKey); err != nil && err != badger.ErrKeyNotFound {
-					return err
+				if msg.VisibilityDeadline.IsZero() || now.Before(msg.VisibilityDeadline) {
+					if err := txn.Delete(exp.indexKey); err != nil && err != badger.ErrKeyNotFound {
+						return err
+					}
+					continue
 				}
-				continue
-			}
-			if msg.VisibilityDeadline.IsZero() || now.Before(msg.VisibilityDeadline) {
-				if err := txn.Delete(exp.indexKey); err != nil && err != badger.ErrKeyNotFound {
-					return err
-				}
-				continue
-			}
 
-			queueID, err := parseMessageKeyQueueID(exp.msgKey)
-			if err != nil {
-				return err
-			}
-			originalSeq, err := parseMessageKeySeq(exp.msgKey)
-			if err != nil {
-				return err
-			}
-
-			if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
-				msg.State = StateDead
-			} else {
-				msg.State = StateReady
-			}
-			msg.VisibilityDeadline = time.Time{}
-			msg.DeliveryAttemptID = ""
-
-			updated, err := json.Marshal(msg)
-			if err != nil {
-				return err
-			}
-			if err := txn.Set(exp.msgKey, updated); err != nil {
-				return err
-			}
-			if err := txn.Delete(exp.indexKey); err != nil && err != badger.ErrKeyNotFound {
-				return err
-			}
-
-			if msg.State == StateReady {
-				newSeq, err := nextMessageSequence(queueID)
+				queueID, err := parseMessageKeyQueueID(exp.msgKey)
 				if err != nil {
-					return fmt.Errorf("allocate reaper sequence: %w", err)
-				}
-				if err := txn.Set(readyKey(queueID, newSeq, msg.ID), readyValue(originalSeq)); err != nil {
 					return err
 				}
+				originalSeq, err := parseMessageKeySeq(exp.msgKey)
+				if err != nil {
+					return err
+				}
+
+				if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
+					msg.State = StateDead
+				} else {
+					msg.State = StateReady
+				}
+				msg.VisibilityDeadline = time.Time{}
+				msg.DeliveryAttemptID = ""
+
+				updated, err := json.Marshal(msg)
+				if err != nil {
+					return err
+				}
+				if err := txn.Set(exp.msgKey, updated); err != nil {
+					return err
+				}
+				if err := txn.Delete(exp.indexKey); err != nil && err != badger.ErrKeyNotFound {
+					return err
+				}
+
+				if msg.State == StateReady {
+					newSeq, err := nextMessageSequence(queueID)
+					if err != nil {
+						return fmt.Errorf("allocate reaper sequence: %w", err)
+					}
+					if err := txn.Set(readyKey(queueID, newSeq, msg.ID), readyValue(originalSeq)); err != nil {
+						return err
+					}
+				}
+
+				transitions = append(transitions, reapTransition{QueueID: queueID, ToState: msg.State})
 			}
-
-			transitions = append(transitions, reapTransition{QueueID: queueID, ToState: msg.State})
+			return nil
+		})
+		if err != nil {
+			return transitions, err
 		}
-		return nil
-	})
+	}
 
-	return transitions, err
+	return transitions, nil
 }
 
 // runs every second and resets expired in-flight messages back to ready in Badger.

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -10,8 +11,8 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"strconv"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -31,7 +32,19 @@ func (e *ErrDeliveryTokenMismatch) Error() string {
 	return fmt.Sprintf("delivery token mismatch: expected %q, got %q", e.Expected, e.Got)
 }
 
+type ErrInvalidReceiptHandle struct {
+	Reason string
+}
+
+func (e *ErrInvalidReceiptHandle) Error() string {
+	if e.Reason == "" {
+		return "invalid receipt handle"
+	}
+	return "invalid receipt handle: " + e.Reason
+}
+
 var ErrNoReadyMessages = errors.New("no ready messages")
+var ErrMessageNotInFlight = errors.New("message is not in flight")
 
 type MessageState string
 
@@ -50,6 +63,11 @@ type Message struct {
 	MaxDeliveryCount   int          `json:"maxDeliveryCount"`
 	VisibilityDeadline time.Time    `json:"visibilityDeadline"`
 	DeliveryAttemptID  string       `json:"deliveryAttemptId"`
+}
+
+type claimedMessage struct {
+	Message
+	ReceiptHandle string `json:"receiptHandle"`
 }
 
 type QueueConfig struct {
@@ -257,6 +275,76 @@ func parseReadyValue(val []byte) (uint64, error) {
 	return binary.BigEndian.Uint64(val), nil
 }
 
+func receiptHandleForMessageKey(key []byte) string {
+	return base64.RawURLEncoding.EncodeToString(key)
+}
+
+func messageKeyFromReceiptHandle(queueID, receiptHandle string) ([]byte, error) {
+	if receiptHandle == "" {
+		return nil, &ErrInvalidReceiptHandle{Reason: "receiptHandle is required"}
+	}
+
+	key, err := base64.RawURLEncoding.DecodeString(receiptHandle)
+	if err != nil {
+		return nil, &ErrInvalidReceiptHandle{Reason: "base64 decode failed"}
+	}
+	if !bytes.HasPrefix(key, queueMessagePrefix(queueID)) {
+		return nil, &ErrInvalidReceiptHandle{Reason: "queue mismatch"}
+	}
+	if _, err := parseMessageKeySeq(key); err != nil {
+		return nil, &ErrInvalidReceiptHandle{Reason: err.Error()}
+	}
+	return key, nil
+}
+
+func inflightPrefix() []byte {
+	return []byte("inflight|")
+}
+
+func inflightKey(queueID string, deadline time.Time, messageID string) []byte {
+	prefix := inflightPrefix()
+	key := make([]byte, 0, len(prefix)+8+1+len(queueID)+1+len(messageID))
+	key = append(key, prefix...)
+
+	var deadlineBytes [8]byte
+	binary.BigEndian.PutUint64(deadlineBytes[:], uint64(deadline.UnixNano()))
+	key = append(key, deadlineBytes[:]...)
+	key = append(key, '|')
+	key = append(key, queueID...)
+	key = append(key, '|')
+	key = append(key, messageID...)
+	return key
+}
+
+func inflightScanUpperBound(now time.Time) []byte {
+	prefix := inflightPrefix()
+	key := make([]byte, 0, len(prefix)+8)
+	key = append(key, prefix...)
+
+	var deadlineBytes [8]byte
+	binary.BigEndian.PutUint64(deadlineBytes[:], uint64(now.UnixNano()))
+	key = append(key, deadlineBytes[:]...)
+	return key
+}
+
+func setInflightIndex(txn *badger.Txn, queueID string, msg Message, msgKey []byte) error {
+	if msg.VisibilityDeadline.IsZero() {
+		return nil
+	}
+	return txn.Set(inflightKey(queueID, msg.VisibilityDeadline, msg.ID), msgKey)
+}
+
+func deleteInflightIndex(txn *badger.Txn, queueID string, msg Message) error {
+	if msg.VisibilityDeadline.IsZero() || msg.ID == "" {
+		return nil
+	}
+	err := txn.Delete(inflightKey(queueID, msg.VisibilityDeadline, msg.ID))
+	if err == badger.ErrKeyNotFound {
+		return nil
+	}
+	return err
+}
+
 func parseMessageKeySeq(key []byte) (uint64, error) {
 	idx := bytes.IndexByte(key, '|')
 	if idx == -1 {
@@ -268,6 +356,17 @@ func parseMessageKeySeq(key []byte) (uint64, error) {
 		return 0, fmt.Errorf("invalid message key format: seq too short")
 	}
 	return binary.BigEndian.Uint64(key[seqStart:seqEnd]), nil
+}
+
+func parseMessageKeyQueueID(key []byte) (string, error) {
+	idx := bytes.IndexByte(key, '|')
+	if idx == -1 {
+		return "", fmt.Errorf("invalid message key format: no delimiter")
+	}
+	if idx == 0 {
+		return "", fmt.Errorf("invalid message key format: empty queue id")
+	}
+	return string(key[:idx]), nil
 }
 
 func readyPartsFromKey(key, prefix []byte) (uint64, []byte, error) {
@@ -321,6 +420,27 @@ func findMessageRecord(txn *badger.Txn, queueID, messageID string) ([]byte, *Mes
 	return nil, nil, badger.ErrKeyNotFound
 }
 
+func messageByReceiptHandle(txn *badger.Txn, queueID, receiptHandle string) ([]byte, *Message, error) {
+	key, err := messageKeyFromReceiptHandle(queueID, receiptHandle)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	item, err := txn.Get(key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var msg Message
+	if err := item.Value(func(v []byte) error {
+		return json.Unmarshal(v, &msg)
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	return key, &msg, nil
+}
+
 func queueReadyChan(queueID string) chan struct{} {
 	queueReadyChansMu.Lock()
 	defer queueReadyChansMu.Unlock()
@@ -371,13 +491,15 @@ type CreateRequest struct {
 }
 
 type AckRequest struct {
-	MessageId     string `json:"messageId"`
+	MessageId     string `json:"messageId,omitempty"`
 	QueueId       string `json:"queueId"`
+	ReceiptHandle string `json:"receiptHandle"`
 	DeliveryToken string `json:"deliveryToken"`
 }
 
 type AckEntry struct {
-	MessageId     string `json:"messageId"`
+	MessageId     string `json:"messageId,omitempty"`
+	ReceiptHandle string `json:"receiptHandle"`
 	DeliveryToken string `json:"deliveryToken"`
 }
 
@@ -559,8 +681,8 @@ func publish(w http.ResponseWriter, r *http.Request) {
 // reads the corresponding message, atomically transitions it to StateInFlight,
 // and deletes the ready pointer — all in a single Db.Update transaction.
 // Returns ErrNoReadyMessages if no ready messages are available.
-func claimNextReadyMessage(queueId string) (*Message, error) {
-	var claimed *Message
+func claimNextReadyMessage(queueId string) (*claimedMessage, error) {
+	var claimed *claimedMessage
 	err := Db.Update(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
 		opts.PrefetchValues = false
@@ -635,8 +757,14 @@ func claimNextReadyMessage(queueId string) (*Message, error) {
 			if err := txn.Set(msgKey, updated); err != nil {
 				return fmt.Errorf("set claimed message: %w", err)
 			}
+			if err := setInflightIndex(txn, queueId, msg, msgKey); err != nil {
+				return fmt.Errorf("set in-flight index: %w", err)
+			}
 
-			claimed = &msg
+			claimed = &claimedMessage{
+				Message:       msg,
+				ReceiptHandle: receiptHandleForMessageKey(msgKey),
+			}
 			return nil
 		}
 		return nil
@@ -650,8 +778,8 @@ func claimNextReadyMessage(queueId string) (*Message, error) {
 	return claimed, nil
 }
 
-func claimReadyMessages(queueId string, max int) ([]Message, error) {
-	var claimed []Message
+func claimReadyMessages(queueId string, max int) ([]claimedMessage, error) {
+	var claimed []claimedMessage
 	err := Db.Update(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
 		opts.PrefetchValues = false
@@ -726,8 +854,14 @@ func claimReadyMessages(queueId string, max int) ([]Message, error) {
 			if err := txn.Set(msgKey, updated); err != nil {
 				return fmt.Errorf("set claimed message: %w", err)
 			}
+			if err := setInflightIndex(txn, queueId, msg, msgKey); err != nil {
+				return fmt.Errorf("set in-flight index: %w", err)
+			}
 
-			claimed = append(claimed, msg)
+			claimed = append(claimed, claimedMessage{
+				Message:       msg,
+				ReceiptHandle: receiptHandleForMessageKey(msgKey),
+			})
 		}
 		return nil
 	})
@@ -768,6 +902,7 @@ func receive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	max := 1
+	maxSpecified := false
 	if maxStr := params.Get("max"); maxStr != "" {
 		parsed, parseErr := strconv.Atoi(maxStr)
 		if parseErr != nil || parsed < 1 || parsed > 100 {
@@ -775,10 +910,11 @@ func receive(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		max = parsed
+		maxSpecified = true
 	}
 
-	if max == 1 {
-		var msg *Message
+	if max == 1 && !maxSpecified {
+		var msg *claimedMessage
 		var claimErr error
 
 		if wait := params.Get("wait"); wait == "true" {
@@ -837,6 +973,7 @@ func receive(w http.ResponseWriter, r *http.Request) {
 			"body":          msg.Body,
 			"state":         StateInFlight,
 			"deliveryToken": msg.DeliveryAttemptID,
+			"receiptHandle": msg.ReceiptHandle,
 		})
 		return
 	}
@@ -886,6 +1023,7 @@ func receive(w http.ResponseWriter, r *http.Request) {
 		Body          []byte       `json:"body"`
 		State         MessageState `json:"state"`
 		DeliveryToken string       `json:"deliveryToken"`
+		ReceiptHandle string       `json:"receiptHandle"`
 	}
 	batch := make([]batchMessage, 0, len(msgs))
 	for _, msg := range msgs {
@@ -894,6 +1032,7 @@ func receive(w http.ResponseWriter, r *http.Request) {
 			Body:          msg.Body,
 			State:         StateInFlight,
 			DeliveryToken: msg.DeliveryAttemptID,
+			ReceiptHandle: msg.ReceiptHandle,
 		})
 	}
 
@@ -937,12 +1076,12 @@ func ack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ackReq.MessageId == "" {
-		http.Error(w, "messageId is required", http.StatusBadRequest)
-		return
-	}
 	if ackReq.QueueId == "" {
 		http.Error(w, "queueId is required", http.StatusBadRequest)
+		return
+	}
+	if ackReq.ReceiptHandle == "" {
+		http.Error(w, "receiptHandle is required", http.StatusBadRequest)
 		return
 	}
 	if ackReq.DeliveryToken == "" {
@@ -954,21 +1093,31 @@ func ack(w http.ResponseWriter, r *http.Request) {
 		if _, err := txn.Get([]byte(ackReq.QueueId)); err != nil {
 			return err
 		}
-		key, msg, err := findMessageRecord(txn, ackReq.QueueId, ackReq.MessageId)
+		key, msg, err := messageByReceiptHandle(txn, ackReq.QueueId, ackReq.ReceiptHandle)
 		if err != nil {
 			return err
+		}
+		if msg.State != StateInFlight {
+			return ErrMessageNotInFlight
 		}
 		if msg.DeliveryAttemptID != ackReq.DeliveryToken {
 			return &ErrDeliveryTokenMismatch{Expected: msg.DeliveryAttemptID, Got: ackReq.DeliveryToken}
 		}
+		if err := deleteInflightIndex(txn, ackReq.QueueId, *msg); err != nil {
+			return err
+		}
 		return txn.Delete(key)
 	})
 	if err != nil {
+		if _, ok := err.(*ErrInvalidReceiptHandle); ok {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		if err == badger.ErrKeyNotFound {
 			http.Error(w, "Queue or message not found", http.StatusNotFound)
 			return
 		}
-		if _, ok := err.(*ErrDeliveryTokenMismatch); ok {
+		if _, ok := err.(*ErrDeliveryTokenMismatch); ok || err == ErrMessageNotInFlight {
 			http.Error(w, err.Error(), http.StatusConflict)
 			return
 		}
@@ -993,9 +1142,10 @@ func handleBatchAck(w http.ResponseWriter, batchReq BatchAckRequest) {
 	}
 
 	type batchAckResult struct {
-		MessageId string `json:"messageId"`
-		Status    string `json:"status"`
-		Error     string `json:"error,omitempty"`
+		MessageId     string `json:"messageId,omitempty"`
+		ReceiptHandle string `json:"receiptHandle,omitempty"`
+		Status        string `json:"status"`
+		Error         string `json:"error,omitempty"`
 	}
 
 	results := make([]batchAckResult, len(batchReq.Acks))
@@ -1007,16 +1157,28 @@ func handleBatchAck(w http.ResponseWriter, batchReq BatchAckRequest) {
 
 		for i, entry := range batchReq.Acks {
 			results[i].MessageId = entry.MessageId
+			results[i].ReceiptHandle = entry.ReceiptHandle
 
-			key, msg, err := findMessageRecord(txn, batchReq.QueueId, entry.MessageId)
+			key, msg, err := messageByReceiptHandle(txn, batchReq.QueueId, entry.ReceiptHandle)
 			if err != nil {
 				results[i].Status = "error"
 				results[i].Error = fmt.Sprintf("message not found: %v", err)
 				continue
 			}
+			results[i].MessageId = msg.ID
+			if msg.State != StateInFlight {
+				results[i].Status = "error"
+				results[i].Error = ErrMessageNotInFlight.Error()
+				continue
+			}
 			if msg.DeliveryAttemptID != entry.DeliveryToken {
 				results[i].Status = "error"
 				results[i].Error = fmt.Sprintf("delivery token mismatch: expected %q, got %q", msg.DeliveryAttemptID, entry.DeliveryToken)
+				continue
+			}
+			if err := deleteInflightIndex(txn, batchReq.QueueId, *msg); err != nil {
+				results[i].Status = "error"
+				results[i].Error = fmt.Sprintf("delete in-flight index failed: %v", err)
 				continue
 			}
 			if err := txn.Delete(key); err != nil {
@@ -1063,12 +1225,12 @@ func nack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ackReq.MessageId == "" {
-		http.Error(w, "messageId is required", http.StatusBadRequest)
-		return
-	}
 	if ackReq.QueueId == "" {
 		http.Error(w, "queueId is required", http.StatusBadRequest)
+		return
+	}
+	if ackReq.ReceiptHandle == "" {
+		http.Error(w, "receiptHandle is required", http.StatusBadRequest)
 		return
 	}
 	if ackReq.DeliveryToken == "" {
@@ -1084,13 +1246,19 @@ func nack(w http.ResponseWriter, r *http.Request) {
 			return err
 		}
 
-		key, msg, err := findMessageRecord(txn, ackReq.QueueId, ackReq.MessageId)
+		key, msg, err := messageByReceiptHandle(txn, ackReq.QueueId, ackReq.ReceiptHandle)
 		if err != nil {
 			return err
 		}
 
+		if msg.State != StateInFlight {
+			return ErrMessageNotInFlight
+		}
 		if msg.DeliveryAttemptID != ackReq.DeliveryToken {
 			return &ErrDeliveryTokenMismatch{Expected: msg.DeliveryAttemptID, Got: ackReq.DeliveryToken}
+		}
+		if err := deleteInflightIndex(txn, ackReq.QueueId, *msg); err != nil {
+			return err
 		}
 
 		if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
@@ -1122,7 +1290,7 @@ func nack(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return fmt.Errorf("allocate nack sequence: %w", err)
 			}
-			if err := txn.Set(readyKey(ackReq.QueueId, newSeq, ackReq.MessageId), readyValue(originalSeq)); err != nil {
+			if err := txn.Set(readyKey(ackReq.QueueId, newSeq, msg.ID), readyValue(originalSeq)); err != nil {
 				return err
 			}
 		}
@@ -1130,11 +1298,15 @@ func nack(w http.ResponseWriter, r *http.Request) {
 		return nil
 	})
 	if err != nil {
+		if _, ok := err.(*ErrInvalidReceiptHandle); ok {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		if err == badger.ErrKeyNotFound {
 			http.Error(w, "Queue or message not found", http.StatusNotFound)
 			return
 		}
-		if _, ok := err.(*ErrDeliveryTokenMismatch); ok {
+		if _, ok := err.(*ErrDeliveryTokenMismatch); ok || err == ErrMessageNotInFlight {
 			http.Error(w, err.Error(), http.StatusConflict)
 			return
 		}
@@ -1170,11 +1342,8 @@ type reapTransition struct {
 
 func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 	type expiredMsg struct {
-		queueID     string
-		msgID       string
-		key         []byte
-		originalSeq uint64
-		toDead      bool
+		indexKey []byte
+		msgKey   []byte
 	}
 
 	var expired []expiredMsg
@@ -1182,45 +1351,22 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 	err := Db.View(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
 		opts.PrefetchValues = true
+		opts.Prefix = inflightPrefix()
 		it := txn.NewIterator(opts)
 		defer it.Close()
 
+		upper := inflightScanUpperBound(now)
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
 			key := item.KeyCopy(nil)
-			if bytes.HasPrefix(key, []byte("ready|")) || bytes.HasPrefix(key, []byte("seq:")) {
-				continue
+			if len(key) >= len(upper) && bytes.Compare(key[:len(upper)], upper) > 0 {
+				break
 			}
-			pipeIndex := bytes.IndexByte(key, '|')
-			if pipeIndex == -1 {
-				continue
-			}
-			queueID := string(key[:pipeIndex])
 
 			if err := item.Value(func(v []byte) error {
-				var msg Message
-				if err := json.Unmarshal(v, &msg); err != nil {
-					return err
-				}
-				if msg.State != StateInFlight {
-					return nil
-				}
-				if msg.VisibilityDeadline.IsZero() || now.Before(msg.VisibilityDeadline) {
-					return nil
-				}
-
-				originalSeq, err := parseMessageKeySeq(key)
-				if err != nil {
-					return err
-				}
-
-				toDead := msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount
 				expired = append(expired, expiredMsg{
-					queueID:     queueID,
-					msgID:       msg.ID,
-					key:         key,
-					originalSeq: originalSeq,
-					toDead:      toDead,
+					indexKey: key,
+					msgKey:   append([]byte(nil), v...),
 				})
 				return nil
 			}); err != nil {
@@ -1237,9 +1383,12 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 
 	err = Db.Update(func(txn *badger.Txn) error {
 		for _, exp := range expired {
-			item, err := txn.Get(exp.key)
+			item, err := txn.Get(exp.msgKey)
 			if err != nil {
 				if err == badger.ErrKeyNotFound {
+					if delErr := txn.Delete(exp.indexKey); delErr != nil && delErr != badger.ErrKeyNotFound {
+						return delErr
+					}
 					continue
 				}
 				return err
@@ -1253,13 +1402,28 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 			}
 
 			if msg.State != StateInFlight {
+				if err := txn.Delete(exp.indexKey); err != nil && err != badger.ErrKeyNotFound {
+					return err
+				}
 				continue
 			}
 			if msg.VisibilityDeadline.IsZero() || now.Before(msg.VisibilityDeadline) {
+				if err := txn.Delete(exp.indexKey); err != nil && err != badger.ErrKeyNotFound {
+					return err
+				}
 				continue
 			}
 
-			if exp.toDead {
+			queueID, err := parseMessageKeyQueueID(exp.msgKey)
+			if err != nil {
+				return err
+			}
+			originalSeq, err := parseMessageKeySeq(exp.msgKey)
+			if err != nil {
+				return err
+			}
+
+			if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
 				msg.State = StateDead
 			} else {
 				msg.State = StateReady
@@ -1271,21 +1435,24 @@ func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
 			if err != nil {
 				return err
 			}
-			if err := txn.Set(exp.key, updated); err != nil {
+			if err := txn.Set(exp.msgKey, updated); err != nil {
+				return err
+			}
+			if err := txn.Delete(exp.indexKey); err != nil && err != badger.ErrKeyNotFound {
 				return err
 			}
 
 			if msg.State == StateReady {
-				newSeq, err := nextMessageSequence(exp.queueID)
+				newSeq, err := nextMessageSequence(queueID)
 				if err != nil {
 					return fmt.Errorf("allocate reaper sequence: %w", err)
 				}
-				if err := txn.Set(readyKey(exp.queueID, newSeq, exp.msgID), readyValue(exp.originalSeq)); err != nil {
+				if err := txn.Set(readyKey(queueID, newSeq, msg.ID), readyValue(originalSeq)); err != nil {
 					return err
 				}
 			}
 
-			transitions = append(transitions, reapTransition{QueueID: exp.queueID, ToState: msg.State})
+			transitions = append(transitions, reapTransition{QueueID: queueID, ToState: msg.State})
 		}
 		return nil
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -127,6 +127,7 @@ type receiveResponse struct {
 	Body          []byte       `json:"body"`
 	State         MessageState `json:"state"`
 	DeliveryToken string       `json:"deliveryToken"`
+	ReceiptHandle string       `json:"receiptHandle"`
 }
 
 func receiveTestMessage(t *testing.T, queueID string) receiveResponse {
@@ -209,9 +210,12 @@ func TestPublishReceiveAck(t *testing.T) {
 	if resp.DeliveryToken == "" {
 		t.Fatal("expected non-empty delivery token")
 	}
+	if resp.ReceiptHandle == "" {
+		t.Fatal("expected non-empty receipt handle")
+	}
 
 	storedKey := storedMessageKey(t, queueID, messageID)
-	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, MessageId: messageID, DeliveryToken: resp.DeliveryToken})
+	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: resp.ReceiptHandle, DeliveryToken: resp.DeliveryToken})
 	if err != nil {
 		t.Fatalf("marshal ack request: %v", err)
 	}
@@ -241,7 +245,7 @@ func TestNackMakesMessageReceivableAgain(t *testing.T) {
 
 	firstResp := receiveTestMessage(t, queueID)
 
-	nackBody, err := json.Marshal(AckRequest{QueueId: queueID, MessageId: messageID, DeliveryToken: firstResp.DeliveryToken})
+	nackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: firstResp.ReceiptHandle, DeliveryToken: firstResp.DeliveryToken})
 	if err != nil {
 		t.Fatalf("marshal nack request: %v", err)
 	}
@@ -288,7 +292,7 @@ func TestReceiveReturnsMessagesInEnqueueOrder(t *testing.T) {
 			t.Fatalf("expected body %s, got %q", expected.body, string(resp.Body))
 		}
 
-		ackBody, err := json.Marshal(AckRequest{QueueId: queueID, MessageId: resp.ID, DeliveryToken: resp.DeliveryToken})
+		ackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: resp.ReceiptHandle, DeliveryToken: resp.DeliveryToken})
 		if err != nil {
 			t.Fatalf("marshal ack request: %v", err)
 		}
@@ -393,6 +397,7 @@ func TestReapExpiredMessagesResetsPersistedInFlightMessage(t *testing.T) {
 
 	firstResp := receiveTestMessage(t, queueID)
 	firstToken := firstResp.DeliveryToken
+	firstReceiptHandle := firstResp.ReceiptHandle
 
 	storedKey := storedMessageKey(t, queueID, messageID)
 	err := Db.Update(func(txn *badger.Txn) error {
@@ -407,6 +412,9 @@ func TestReapExpiredMessagesResetsPersistedInFlightMessage(t *testing.T) {
 				return err
 			}
 
+			if err := deleteInflightIndex(txn, queueID, msg); err != nil {
+				return err
+			}
 			msg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
 
 			updated, err := json.Marshal(msg)
@@ -414,7 +422,10 @@ func TestReapExpiredMessagesResetsPersistedInFlightMessage(t *testing.T) {
 				return err
 			}
 
-			return txn.Set(storedKey, updated)
+			if err := txn.Set(storedKey, updated); err != nil {
+				return err
+			}
+			return setInflightIndex(txn, queueID, msg, storedKey)
 		})
 	})
 	if err != nil {
@@ -442,7 +453,7 @@ func TestReapExpiredMessagesResetsPersistedInFlightMessage(t *testing.T) {
 	}
 
 	// Stale delivery token should be rejected
-	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, MessageId: messageID, DeliveryToken: firstToken})
+	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: firstReceiptHandle, DeliveryToken: firstToken})
 	if err != nil {
 		t.Fatalf("marshal ack request: %v", err)
 	}
@@ -458,11 +469,11 @@ func TestAckRejectsWrongDeliveryToken(t *testing.T) {
 	setupTestDB(t)
 
 	queueID := createTestQueue(t, "token-queue")
-	messageID := publishTestMessage(t, queueID, []byte("secret"))
+	_ = publishTestMessage(t, queueID, []byte("secret"))
 
-	_ = receiveTestMessage(t, queueID)
+	resp := receiveTestMessage(t, queueID)
 
-	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, MessageId: messageID, DeliveryToken: "wrong-token"})
+	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: resp.ReceiptHandle, DeliveryToken: "wrong-token"})
 	if err != nil {
 		t.Fatalf("marshal ack request: %v", err)
 	}
@@ -480,11 +491,11 @@ func TestNackRejectsWrongDeliveryToken(t *testing.T) {
 	setupTestDB(t)
 
 	queueID := createTestQueue(t, "nack-token-queue")
-	messageID := publishTestMessage(t, queueID, []byte("secret"))
+	_ = publishTestMessage(t, queueID, []byte("secret"))
 
-	_ = receiveTestMessage(t, queueID)
+	resp := receiveTestMessage(t, queueID)
 
-	nackBody, err := json.Marshal(AckRequest{QueueId: queueID, MessageId: messageID, DeliveryToken: "wrong-token"})
+	nackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: resp.ReceiptHandle, DeliveryToken: "wrong-token"})
 	if err != nil {
 		t.Fatalf("marshal nack request: %v", err)
 	}
@@ -495,6 +506,104 @@ func TestNackRejectsWrongDeliveryToken(t *testing.T) {
 
 	if nackRecorder.Code != http.StatusConflict {
 		t.Fatalf("expected 409 for wrong delivery token, got %d: %s", nackRecorder.Code, nackRecorder.Body.String())
+	}
+}
+
+func TestAckRejectsMalformedReceiptHandle(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "bad-handle-queue")
+
+	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: "not-base64!", DeliveryToken: "token"})
+	if err != nil {
+		t.Fatalf("marshal ack request: %v", err)
+	}
+
+	ackReq := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(ackBody))
+	ackRecorder := httptest.NewRecorder()
+	ack(ackRecorder, ackReq)
+
+	if ackRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed receipt handle, got %d: %s", ackRecorder.Code, ackRecorder.Body.String())
+	}
+}
+
+func TestAckRejectsWrongQueueReceiptHandle(t *testing.T) {
+	setupTestDB(t)
+
+	queueAID := createTestQueue(t, "queue-a")
+	queueBID := createTestQueue(t, "queue-b")
+	publishTestMessage(t, queueAID, []byte("secret"))
+
+	resp := receiveTestMessage(t, queueAID)
+
+	ackBody, err := json.Marshal(AckRequest{QueueId: queueBID, ReceiptHandle: resp.ReceiptHandle, DeliveryToken: resp.DeliveryToken})
+	if err != nil {
+		t.Fatalf("marshal ack request: %v", err)
+	}
+
+	ackReq := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(ackBody))
+	ackRecorder := httptest.NewRecorder()
+	ack(ackRecorder, ackReq)
+
+	if ackRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for wrong queue receipt handle, got %d: %s", ackRecorder.Code, ackRecorder.Body.String())
+	}
+}
+
+func TestAckDeletesInflightIndex(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "ack-index-queue")
+	publishTestMessage(t, queueID, []byte("indexed"))
+
+	resp := receiveTestMessage(t, queueID)
+
+	err := Db.View(func(txn *badger.Txn) error {
+		key, err := messageKeyFromReceiptHandle(queueID, resp.ReceiptHandle)
+		if err != nil {
+			return err
+		}
+		item, err := txn.Get(key)
+		if err != nil {
+			return err
+		}
+		return item.Value(func(v []byte) error {
+			var msg Message
+			if err := json.Unmarshal(v, &msg); err != nil {
+				return err
+			}
+			_, err = txn.Get(inflightKey(queueID, msg.VisibilityDeadline, msg.ID))
+			return err
+		})
+	})
+	if err != nil {
+		t.Fatalf("expected in-flight index after receive: %v", err)
+	}
+
+	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: resp.ReceiptHandle, DeliveryToken: resp.DeliveryToken})
+	if err != nil {
+		t.Fatalf("marshal ack request: %v", err)
+	}
+	ackReq := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(ackBody))
+	ackRecorder := httptest.NewRecorder()
+	ack(ackRecorder, ackReq)
+	if ackRecorder.Code != http.StatusAccepted {
+		t.Fatalf("ack status = %d, body = %s", ackRecorder.Code, ackRecorder.Body.String())
+	}
+
+	err = Db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = inflightPrefix()
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			t.Fatalf("expected no in-flight index keys, found %q", it.Item().Key())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan in-flight index: %v", err)
 	}
 }
 
@@ -531,12 +640,18 @@ func TestReapDeadLettersAfterMaxDeliveries(t *testing.T) {
 			if err := json.Unmarshal(v, &msg); err != nil {
 				return err
 			}
+			if err := deleteInflightIndex(txn, queueID, msg); err != nil {
+				return err
+			}
 			msg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
 			updated, err := json.Marshal(msg)
 			if err != nil {
 				return err
 			}
-			return txn.Set(storedKey, updated)
+			if err := txn.Set(storedKey, updated); err != nil {
+				return err
+			}
+			return setInflightIndex(txn, queueID, msg, storedKey)
 		})
 	})
 	if err != nil {
@@ -563,6 +678,60 @@ func TestReapDeadLettersAfterMaxDeliveries(t *testing.T) {
 	}
 }
 
+func TestReaperUsesInflightIndexWithReadyBacklog(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "indexed-reaper-queue")
+	messageID := publishTestMessage(t, queueID, []byte("expired"))
+	resp := receiveTestMessage(t, queueID)
+	if resp.ID != messageID {
+		t.Fatalf("expected received message %s, got %s", messageID, resp.ID)
+	}
+	for i := 0; i < 50; i++ {
+		publishTestMessage(t, queueID, []byte("ready-backlog"))
+	}
+
+	storedKey := storedMessageKey(t, queueID, messageID)
+	err := Db.Update(func(txn *badger.Txn) error {
+		item, err := txn.Get(storedKey)
+		if err != nil {
+			return err
+		}
+		return item.Value(func(v []byte) error {
+			var msg Message
+			if err := json.Unmarshal(v, &msg); err != nil {
+				return err
+			}
+			if err := deleteInflightIndex(txn, queueID, msg); err != nil {
+				return err
+			}
+			msg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
+			updated, err := json.Marshal(msg)
+			if err != nil {
+				return err
+			}
+			if err := txn.Set(storedKey, updated); err != nil {
+				return err
+			}
+			return setInflightIndex(txn, queueID, msg, storedKey)
+		})
+	})
+	if err != nil {
+		t.Fatalf("prepare expired in-flight message: %v", err)
+	}
+
+	transitions, err := reapExpiredMessages(time.Now())
+	if err != nil {
+		t.Fatalf("reap expired messages: %v", err)
+	}
+	if len(transitions) != 1 {
+		t.Fatalf("expected one indexed reaper transition, got %d", len(transitions))
+	}
+	if transitions[0].QueueID != queueID || transitions[0].ToState != StateReady {
+		t.Fatalf("unexpected transition: %+v", transitions[0])
+	}
+}
+
 func TestNackDeadLettersAfterMaxDeliveries(t *testing.T) {
 	setupTestDB(t)
 
@@ -585,7 +754,7 @@ func TestNackDeadLettersAfterMaxDeliveries(t *testing.T) {
 
 	resp := receiveTestMessage(t, queueID)
 
-	nackBody, err := json.Marshal(AckRequest{QueueId: queueID, MessageId: messageID, DeliveryToken: resp.DeliveryToken})
+	nackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: resp.ReceiptHandle, DeliveryToken: resp.DeliveryToken})
 	if err != nil {
 		t.Fatalf("marshal nack request: %v", err)
 	}
@@ -755,19 +924,195 @@ func receiveBenchMessage(b testing.TB, queueID string) receiveResponse {
 	return resp
 }
 
+func ackClaimedMessagesBench(b testing.TB, queueID string, msgs []claimedMessage) {
+	b.Helper()
+
+	acks := make([]AckEntry, 0, len(msgs))
+	for _, msg := range msgs {
+		acks = append(acks, AckEntry{
+			ReceiptHandle: msg.ReceiptHandle,
+			DeliveryToken: msg.DeliveryAttemptID,
+		})
+	}
+
+	body, err := json.Marshal(BatchAckRequest{QueueId: queueID, Acks: acks})
+	if err != nil {
+		b.Fatalf("marshal batch ack: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	ack(rec, req)
+	if rec.Code != http.StatusAccepted {
+		b.Fatalf("ack status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func setupDepthBenchmarkDB(b *testing.B) string {
+	b.Helper()
+
+	db, err := badger.Open(badger.DefaultOptions(b.TempDir()).WithLogger(nil))
+	if err != nil {
+		b.Fatalf("open bench db: %v", err)
+	}
+
+	Db = db
+	Queues = nil
+	DeadLetterQueue = nil
+	receiveChannel = make(chan struct{}, 1)
+	queueReadyChans = map[string]chan struct{}{}
+	metricsStore = sync.Map{}
+
+	b.Cleanup(func() {
+		_ = db.Close()
+		Db = nil
+	})
+
+	return createBenchQueue(b, "depth-bench-queue")
+}
+
+func BenchmarkBatchReceiveOnly(b *testing.B) {
+	const batchSize = 10
+	for _, depth := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("depth_%d", depth), func(b *testing.B) {
+			queueID := setupDepthBenchmarkDB(b)
+			for i := 0; i < depth+b.N*batchSize; i++ {
+				publishBenchMessage(b, queueID, []byte("fill"))
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				msgs, err := claimReadyMessages(queueID, batchSize)
+				if err != nil {
+					b.Fatalf("claim batch: %v", err)
+				}
+				if len(msgs) != batchSize {
+					b.Fatalf("claimed %d messages, want %d", len(msgs), batchSize)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkBatchAckOnly(b *testing.B) {
+	const batchSize = 10
+	for _, depth := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("depth_%d", depth), func(b *testing.B) {
+			queueID := setupDepthBenchmarkDB(b)
+			for i := 0; i < depth+b.N*batchSize; i++ {
+				publishBenchMessage(b, queueID, []byte("fill"))
+			}
+
+			batches := make([][]claimedMessage, 0, b.N)
+			for i := 0; i < b.N; i++ {
+				msgs, err := claimReadyMessages(queueID, batchSize)
+				if err != nil {
+					b.Fatalf("claim batch: %v", err)
+				}
+				batches = append(batches, msgs)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ackClaimedMessagesBench(b, queueID, batches[i])
+			}
+		})
+	}
+}
+
+func BenchmarkBatchReceiveAndAck(b *testing.B) {
+	const batchSize = 10
+	for _, depth := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("depth_%d", depth), func(b *testing.B) {
+			queueID := setupDepthBenchmarkDB(b)
+			for i := 0; i < depth+b.N*batchSize; i++ {
+				publishBenchMessage(b, queueID, []byte("fill"))
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				msgs, err := claimReadyMessages(queueID, batchSize)
+				if err != nil {
+					b.Fatalf("claim batch: %v", err)
+				}
+				ackClaimedMessagesBench(b, queueID, msgs)
+			}
+		})
+	}
+}
+
+func BenchmarkReaperDueInflightIndex(b *testing.B) {
+	for _, readyDepth := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("ready_depth_%d", readyDepth), func(b *testing.B) {
+			queueID := setupDepthBenchmarkDB(b)
+			for i := 0; i < readyDepth; i++ {
+				publishBenchMessage(b, queueID, []byte("ready"))
+			}
+
+			for i := 0; i < b.N; i++ {
+				publishBenchMessage(b, queueID, []byte("expired"))
+				resp := receiveBenchMessage(b, queueID)
+				key, err := messageKeyFromReceiptHandle(queueID, resp.ReceiptHandle)
+				if err != nil {
+					b.Fatalf("decode receipt handle: %v", err)
+				}
+				err = Db.Update(func(txn *badger.Txn) error {
+					item, err := txn.Get(key)
+					if err != nil {
+						return err
+					}
+					return item.Value(func(v []byte) error {
+						var msg Message
+						if err := json.Unmarshal(v, &msg); err != nil {
+							return err
+						}
+						if err := deleteInflightIndex(txn, queueID, msg); err != nil {
+							return err
+						}
+						msg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
+						updated, err := json.Marshal(msg)
+						if err != nil {
+							return err
+						}
+						if err := txn.Set(key, updated); err != nil {
+							return err
+						}
+						return setInflightIndex(txn, queueID, msg, key)
+					})
+				})
+				if err != nil {
+					b.Fatalf("prepare expired message: %v", err)
+				}
+			}
+
+			b.ResetTimer()
+			transitions, err := reapExpiredMessages(time.Now())
+			b.StopTimer()
+			if err != nil {
+				b.Fatalf("reap expired messages: %v", err)
+			}
+			if len(transitions) != b.N {
+				b.Fatalf("reaped %d messages, want %d", len(transitions), b.N)
+			}
+		})
+	}
+}
+
 type batchReceiveResponse struct {
 	Messages []struct {
 		ID            string       `json:"id"`
 		Body          []byte       `json:"body"`
 		State         MessageState `json:"state"`
 		DeliveryToken string       `json:"deliveryToken"`
+		ReceiptHandle string       `json:"receiptHandle"`
 	} `json:"messages"`
 }
 
 type batchAckResult struct {
-	MessageId string `json:"messageId"`
-	Status    string `json:"status"`
-	Error     string `json:"error,omitempty"`
+	MessageId     string `json:"messageId"`
+	ReceiptHandle string `json:"receiptHandle"`
+	Status        string `json:"status"`
+	Error         string `json:"error,omitempty"`
 }
 
 type batchAckResponse struct {
@@ -810,6 +1155,9 @@ func TestBatchReceiveReturnsMultipleMessages(t *testing.T) {
 		}
 		if m.DeliveryToken == "" {
 			t.Fatalf("message %s has empty delivery token", m.ID)
+		}
+		if m.ReceiptHandle == "" {
+			t.Fatalf("message %s has empty receipt handle", m.ID)
 		}
 	}
 }
@@ -886,9 +1234,9 @@ func TestBatchAckMultipleMessages(t *testing.T) {
 	ackBody, _ := json.Marshal(BatchAckRequest{
 		QueueId: queueID,
 		Acks: []AckEntry{
-			{MessageId: msg1ID, DeliveryToken: batchResp.Messages[0].DeliveryToken},
-			{MessageId: msg2ID, DeliveryToken: batchResp.Messages[1].DeliveryToken},
-			{MessageId: msg3ID, DeliveryToken: batchResp.Messages[2].DeliveryToken},
+			{ReceiptHandle: batchResp.Messages[0].ReceiptHandle, DeliveryToken: batchResp.Messages[0].DeliveryToken},
+			{ReceiptHandle: batchResp.Messages[1].ReceiptHandle, DeliveryToken: batchResp.Messages[1].DeliveryToken},
+			{ReceiptHandle: batchResp.Messages[2].ReceiptHandle, DeliveryToken: batchResp.Messages[2].DeliveryToken},
 		},
 	})
 
@@ -931,7 +1279,7 @@ func TestBatchAckReportsPartialErrors(t *testing.T) {
 
 	queueID := createTestQueue(t, "batch-ack-err-queue")
 
-	msg1ID := publishTestMessage(t, queueID, []byte("one"))
+	_ = publishTestMessage(t, queueID, []byte("one"))
 	msg2ID := publishTestMessage(t, queueID, []byte("two"))
 
 	batchResp := func() batchReceiveResponse {
@@ -949,8 +1297,8 @@ func TestBatchAckReportsPartialErrors(t *testing.T) {
 	ackBody, _ := json.Marshal(BatchAckRequest{
 		QueueId: queueID,
 		Acks: []AckEntry{
-			{MessageId: msg1ID, DeliveryToken: batchResp.Messages[0].DeliveryToken},
-			{MessageId: msg2ID, DeliveryToken: "wrong-token"},
+			{ReceiptHandle: batchResp.Messages[0].ReceiptHandle, DeliveryToken: batchResp.Messages[0].DeliveryToken},
+			{ReceiptHandle: batchResp.Messages[1].ReceiptHandle, DeliveryToken: "wrong-token"},
 		},
 	})
 


### PR DESCRIPTION
- Add receiptHandle field (base64-encoded message key) for ack/nack operations
- Add in-flight index (inflight|) for O(1) expired message lookups in reaper
- Replace messageId with receiptHandle in AckRequest and AckEntry
- Return receiptHandle in receive responses (single and batch)
- Update benchmark tool to use new receipt handle API
- Add tests for receipt handle validation and in-flight index cleanup
- Add benchmarks for batch receive/ack at different queue depths

BREAKING CHANGE: Clients must now use receiptHandle instead of messageId for ack/nack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/receive` endpoint responses now include a `receiptHandle` identifier for each message.
  * `/ack` and `/nack` endpoints updated to use `receiptHandle` for message operations.
  * Enhanced in-flight message tracking and cleanup efficiency.

* **Documentation**
  * New performance model documentation with queue complexity analysis and benchmark guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->