### PR TITLE
ci: run benchmark workflow on PRs to master

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,8 @@ name: Benchmark
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   benchmark:


### PR DESCRIPTION
Triggers the benchmark workflow on pull_request events targeting master, in addition to the existing push trigger. This gives benchmark visibility on PRs before merge.