### PR TITLE
Throttle metrics reconciliation

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,9 +117,13 @@ type queueMetrics struct {
 	totalNacked    atomic.Int64
 	ackCountWindow atomic.Int64 // acks in last second (approximate, updated by reaper)
 	startedAt      time.Time
+	reconcileMu    sync.Mutex
+	lastReconcile  time.Time
 }
 
 var metricsStore sync.Map
+
+const metricsReconcileInterval = 10 * time.Second
 
 func snapshotMax(counter *atomic.Int64, val int64) {
 	for {
@@ -199,6 +203,20 @@ func reconcileMetricsFromDB(queueID string, m *queueMetrics) error {
 	snapshotMax(&m.readyCount, ready)
 	snapshotMax(&m.inFlightCount, inFlight)
 	snapshotMax(&m.deadCount, dead)
+	return nil
+}
+
+func reconcileMetricsFromDBIfStale(queueID string, m *queueMetrics, now time.Time) error {
+	m.reconcileMu.Lock()
+	defer m.reconcileMu.Unlock()
+
+	if !m.lastReconcile.IsZero() && now.Sub(m.lastReconcile) < metricsReconcileInterval {
+		return nil
+	}
+	if err := reconcileMetricsFromDB(queueID, m); err != nil {
+		return err
+	}
+	m.lastReconcile = now
 	return nil
 }
 
@@ -1785,11 +1803,10 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	closer.Close()
 
 	m := getOrCreateMetrics(id)
-	if err := reconcileMetricsFromDB(id, m); err != nil {
+	if err := reconcileMetricsFromDBIfStale(id, m, time.Now()); err != nil {
 		http.Error(w, "Error reconciling metrics: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	m.resetAckWindow()
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/main.go
+++ b/main.go
@@ -213,11 +213,9 @@ func reconcileMetricsFromDBIfStale(queueID string, m *queueMetrics, now time.Tim
 	if !m.lastReconcile.IsZero() && now.Sub(m.lastReconcile) < metricsReconcileInterval {
 		return nil
 	}
-	if err := reconcileMetricsFromDB(queueID, m); err != nil {
-		return err
-	}
+	err := reconcileMetricsFromDB(queueID, m)
 	m.lastReconcile = now
-	return nil
+	return err
 }
 
 // channel for long polling in receive

--- a/main_test.go
+++ b/main_test.go
@@ -892,6 +892,42 @@ func TestAckRatePerSec_EmptyWindow(t *testing.T) {
 	}
 }
 
+func TestReconcileMetricsFromDBIfStaleSkipsWithinInterval(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "metrics-throttle-queue")
+	key := messageKey(queueID, 1, "bad-message")
+	if err := Db.Set(key, []byte("{bad json"), pebble.Sync); err != nil {
+		t.Fatalf("write malformed message: %v", err)
+	}
+
+	m := getOrCreateMetrics(queueID)
+	now := time.Now()
+	m.lastReconcile = now.Add(-metricsReconcileInterval / 2)
+
+	if err := reconcileMetricsFromDBIfStale(queueID, m, now); err != nil {
+		t.Fatalf("reconcile inside throttle interval returned error: %v", err)
+	}
+}
+
+func TestReconcileMetricsFromDBIfStaleRunsAfterInterval(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "metrics-throttle-expired-queue")
+	key := messageKey(queueID, 1, "bad-message")
+	if err := Db.Set(key, []byte("{bad json"), pebble.Sync); err != nil {
+		t.Fatalf("write malformed message: %v", err)
+	}
+
+	m := getOrCreateMetrics(queueID)
+	now := time.Now()
+	m.lastReconcile = now.Add(-metricsReconcileInterval)
+
+	if err := reconcileMetricsFromDBIfStale(queueID, m, now); err == nil {
+		t.Fatal("expected reconcile after throttle interval to scan DB and return an error")
+	}
+}
+
 func receiveBenchMessage(b testing.TB, queueID string) receiveResponse {
 	b.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID, nil)

--- a/main_test.go
+++ b/main_test.go
@@ -926,6 +926,12 @@ func TestReconcileMetricsFromDBIfStaleRunsAfterInterval(t *testing.T) {
 	if err := reconcileMetricsFromDBIfStale(queueID, m, now); err == nil {
 		t.Fatal("expected reconcile after throttle interval to scan DB and return an error")
 	}
+	if !m.lastReconcile.Equal(now) {
+		t.Fatalf("lastReconcile = %v, want %v", m.lastReconcile, now)
+	}
+	if err := reconcileMetricsFromDBIfStale(queueID, m, now.Add(time.Second)); err != nil {
+		t.Fatalf("expected failed reconcile to be throttled, got error: %v", err)
+	}
 }
 
 func receiveBenchMessage(b testing.TB, queueID string) receiveResponse {


### PR DESCRIPTION
## Summary
- throttle per-queue DB reconciliation on /metrics to once every 10 seconds
- serialize reconciliation per queue so concurrent scrapes do not all scan Pebble
- stop resetting the ack window from /metrics; the reaper already owns that reset
- add tests for skipped vs expired reconciliation intervals

Fixes #6

## Tests
- go test ./...
- go build ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics endpoint performance by reducing unnecessary database scans. Metrics reconciliation now uses intelligent caching with a 10-second interval, preventing redundant lookups.

* **Tests**
  * Added unit tests to validate metrics reconciliation behavior during normal operation and after cache expiration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ayan-sh03/kueue/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->