### PR TITLE
Phase 2.2: Add in-memory queueRuntime state model

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"container/heap"
+	"container/list"
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -1873,4 +1876,173 @@ func main() {
 		log.Fatalf("server failed: %v", err)
 	}
 
+}
+
+// ============================================================================
+// Phase 2.2: In-memory queueRuntime state model
+// ============================================================================
+
+// walAppender is the minimal interface the queue manager needs from the WAL.
+// walStore already satisfies this. A fake implementation is used in tests.
+type walAppender interface {
+	Append(ctx context.Context, entries []walEntry) (firstLSN, lastLSN uint64, err error)
+}
+
+// messageRecord is the in-memory representation of a message.
+// Body is immutable after publish (caller must copy input).
+type messageRecord struct {
+	ID               string
+	QueueID          string
+	Seq              uint64
+	Body             []byte
+	State            MessageState
+	EnqueuedAt       time.Time
+	DeliveryCount    int
+	MaxDeliveryCount int
+
+	CurrentReceiptHandle string
+	CurrentDeliveryToken string
+	VisibilityDeadline   time.Time
+
+	readyElement *list.Element // list node for O(1) removal from ready list
+	heapIndex    int           // index in visibilityHeap; -1 when not in heap
+}
+
+// deliveryRecord tracks an in-flight delivery for O(1) ack/nack lookup.
+type deliveryRecord struct {
+	MessageID     string
+	ReceiptHandle string
+	DeliveryToken string
+	Deadline      time.Time
+	DeliveryCount int
+	heapIndex     int // index in visibilityHeap
+}
+
+// ============================================================================
+// visibilityHeap
+// ============================================================================
+
+// visibilityHeap is a min-heap of *deliveryRecord ordered by Deadline.
+type visibilityHeap []*deliveryRecord
+
+func (h visibilityHeap) Len() int { return len(h) }
+func (h visibilityHeap) Less(i, j int) bool {
+	return h[i].Deadline.Before(h[j].Deadline)
+}
+func (h visibilityHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].heapIndex = i
+	h[j].heapIndex = j
+}
+
+func (h *visibilityHeap) Push(x any) {
+	dr := x.(*deliveryRecord)
+	dr.heapIndex = len(*h)
+	*h = append(*h, dr)
+}
+
+func (h *visibilityHeap) Pop() any {
+	old := *h
+	n := len(old)
+	dr := old[n-1]
+	dr.heapIndex = -1
+	*h = old[0 : n-1]
+	return dr
+}
+
+// ============================================================================
+// queueRuntime: per-queue in-memory state
+// ============================================================================
+
+type queueRuntime struct {
+	mu sync.Mutex
+
+	id     string
+	config QueueConfig
+
+	nextSeq uint64
+
+	ready    *list.List                    // []*messageRecord — FIFO order
+	messages map[string]*messageRecord     // keyed by message ID
+	inflight map[string]*deliveryRecord    // keyed by receiptHandle
+	dead     map[string]*messageRecord
+
+	deadlines visibilityHeap // min-heap of *deliveryRecord
+
+	readyCh chan struct{}
+	metrics *queueMetrics
+
+	maxMessages int64
+	maxBytes    int64
+	bytesInMem  int64
+}
+
+func newQueueRuntime(id string, config QueueConfig, metrics *queueMetrics) *queueRuntime {
+	q := &queueRuntime{
+		id:          id,
+		config:      config,
+		ready:       list.New(),
+		messages:    make(map[string]*messageRecord),
+		inflight:    make(map[string]*deliveryRecord),
+		dead:        make(map[string]*messageRecord),
+		readyCh:     make(chan struct{}, 1),
+		metrics:     metrics,
+		maxMessages: parseInt64Env("KUEUE_MAX_IN_MEMORY_MESSAGES", 0),
+		maxBytes:    parseInt64Env("KUEUE_MAX_IN_MEMORY_BYTES", 0),
+	}
+	heap.Init(&q.deadlines)
+	return q
+}
+
+func parseInt64Env(name string, defaultVal int64) int64 {
+	s := os.Getenv(name)
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return defaultVal
+	}
+	return v
+}
+
+// receiptHandleForMessage returns a deterministic receipt handle for a message.
+func receiptHandleForMessage(queueID string, seq uint64, messageID string) string {
+	raw := queueID + "|" + strconv.FormatUint(seq, 10) + "|" + messageID
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func (q *queueRuntime) signalReady() {
+	select {
+	case q.readyCh <- struct{}{}:
+	default:
+	}
+}
+
+// ============================================================================
+// queueManager: process-wide manager
+// ============================================================================
+
+type queueManager struct {
+	mu     sync.RWMutex
+	queues map[string]*queueRuntime
+	wal    walAppender
+}
+
+func newQueueManager(wal walAppender) *queueManager {
+	return &queueManager{
+		queues: make(map[string]*queueRuntime),
+		wal:    wal,
+	}
+}
+
+// getQueue returns the queueRuntime for an existing queue.
+func (qm *queueManager) getQueue(queueID string) (*queueRuntime, error) {
+	qm.mu.RLock()
+	q, ok := qm.queues[queueID]
+	qm.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("queue %q not found", queueID)
+	}
+	return q, nil
 }

--- a/main.go
+++ b/main.go
@@ -2311,9 +2311,15 @@ func (qm *queueManager) AckBatch(ctx context.Context, queueID string, acks []Ack
 
 	// Validate each entry and collect valid ones for WAL.
 	valid := make([]*deliveryRecord, 0, len(acks))
+	seen := make(map[string]bool, len(acks))
 	results := make([]runtimeAckResult, len(acks))
 	for i, entry := range acks {
 		results[i].ReceiptHandle = entry.ReceiptHandle
+		if seen[entry.ReceiptHandle] {
+			results[i].Status = "error"
+			results[i].Error = "duplicate receipt handle"
+			continue
+		}
 		dr, ok := q.inflight[entry.ReceiptHandle]
 		if !ok {
 			results[i].Status = "error"
@@ -2325,6 +2331,7 @@ func (qm *queueManager) AckBatch(ctx context.Context, queueID string, acks []Ack
 			results[i].Error = (&ErrDeliveryTokenMismatch{Expected: dr.DeliveryToken, Got: entry.DeliveryToken}).Error()
 			continue
 		}
+		seen[entry.ReceiptHandle] = true
 		valid = append(valid, dr)
 		results[i].Status = "ok"
 	}

--- a/main.go
+++ b/main.go
@@ -2232,21 +2232,19 @@ func (qm *queueManager) ClaimBatch(ctx context.Context, queueID string, max int)
 		},
 	}
 	if _, _, err := qm.wal.Append(ctx, []walEntry{entry}); err != nil {
-		// Rollback: restore popped records to ready front in reverse order.
+		// Rollback: restore popped records to ready front in reverse order
+		// and remove the delivery records added to inflight/heap.
 		for i := len(popped) - 1; i >= 0; i-- {
 			msg := popped[i]
+			rh := msg.CurrentReceiptHandle
 			msg.State = StateReady
 			msg.CurrentReceiptHandle = ""
 			msg.CurrentDeliveryToken = ""
 			msg.VisibilityDeadline = time.Time{}
 			msg.DeliveryCount--
 			msg.readyElement = q.ready.PushFront(msg)
-			delete(q.inflight, msg.CurrentReceiptHandle)
+			delete(q.inflight, rh)
 		}
-		// Clean up any heap entries that were added (they'll be stale but harmless
-		// until the reaper tries to process them; we'll rebuild the heap from
-		// inflight on the next operation that needs it).
-		// Simpler: rebuild the heap from the current inflight map.
 		q.deadlines = q.deadlines[:0]
 		for _, dr := range q.inflight {
 			dr.heapIndex = -1

--- a/main.go
+++ b/main.go
@@ -2362,7 +2362,10 @@ func (qm *queueManager) AckBatch(ctx context.Context, queueID string, acks []Ack
 			heap.Remove(&q.deadlines, dr.heapIndex)
 		}
 		delete(q.inflight, dr.ReceiptHandle)
-		delete(q.messages, dr.MessageID)
+		if msg, ok := q.messages[dr.MessageID]; ok {
+			q.bytesInMem -= int64(len(msg.Body))
+			delete(q.messages, dr.MessageID)
+		}
 	}
 	q.metrics.inFlightCount.Add(-int64(len(valid)))
 	q.metrics.totalAcked.Add(int64(len(valid)))

--- a/main.go
+++ b/main.go
@@ -2489,6 +2489,15 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 		var transitions []reapTransition
 		var reaps []walReapedMessage
 
+		// Collect expired deliveries without mutating state yet.
+		type pendingReap struct {
+			dr          *deliveryRecord
+			msg         *messageRecord
+			targetState MessageState
+			newSeq      uint64
+		}
+		var pending []pendingReap
+
 		for len(q.deadlines) > 0 && q.deadlines[0].Deadline.Before(now) {
 			dr := heap.Pop(&q.deadlines).(*deliveryRecord)
 			msg, ok := q.messages[dr.MessageID]
@@ -2498,35 +2507,29 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 			if msg.State != StateInFlight {
 				continue
 			}
-			// Guard against stale heap entries (token changed since push).
 			if msg.CurrentDeliveryToken != dr.DeliveryToken {
 				continue
 			}
 			if msg.VisibilityDeadline.After(now) {
-				// Should not happen because heap ordering, but guard.
 				continue
 			}
-
-			// Remove from inflight.
-			delete(q.inflight, dr.ReceiptHandle)
 
 			var targetState MessageState
 			var newSeq uint64
 			if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
 				targetState = StateDead
-				msg.State = StateDead
-				q.dead[msg.ID] = msg
 			} else {
 				targetState = StateReady
-				msg.State = StateReady
 				newSeq = q.nextSeq
 				q.nextSeq++
-				msg.Seq = newSeq
-				msg.CurrentReceiptHandle = ""
-				msg.CurrentDeliveryToken = ""
-				msg.VisibilityDeadline = time.Time{}
-				msg.readyElement = q.ready.PushBack(msg)
 			}
+
+			pending = append(pending, pendingReap{
+				dr:          dr,
+				msg:         msg,
+				targetState: targetState,
+				newSeq:      newSeq,
+			})
 
 			reaps = append(reaps, walReapedMessage{
 				MessageID:             msg.ID,
@@ -2539,6 +2542,13 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 		}
 
 		if len(reaps) == 0 {
+			// Nothing expired, but we may have popped stale entries from the heap.
+			// Push any valid inflight entries back.
+			q.deadlines = q.deadlines[:0]
+			for _, dr := range q.inflight {
+				dr.heapIndex = -1
+				heap.Push(&q.deadlines, dr)
+			}
 			q.mu.Unlock()
 			continue
 		}
@@ -2551,26 +2561,14 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 			},
 		}
 		if _, _, err := qm.wal.Append(ctx, []walEntry{entry}); err != nil {
-			// Rollback: restore all transitioned messages to inflight.
-			for _, tr := range reaps {
-				msg := q.messages[tr.MessageID]
-				if msg == nil {
-					continue
+			// WAL failed — no mutations were applied. The delivery records
+			// are still in q.inflight. Rebuild the heap from the inflight
+			// map (which is unchanged) and rollback seq allocations.
+			for _, p := range pending {
+				if p.targetState == StateReady {
+					q.nextSeq-- // rollback seq allocation
 				}
-				if tr.TargetState == StateReady {
-					q.ready.Remove(msg.readyElement)
-					msg.readyElement = nil
-					q.nextSeq = tr.NewReadySeq
-				} else {
-					delete(q.dead, msg.ID)
-				}
-				msg.State = StateInFlight
-				msg.Seq = 0 // we don't restore seq; it'll be set correctly on next claim
-				// Rebuild receipt handle and token from the original delivery record
-				// is impossible here, so we rebuild the heap from current inflight map
-				// and skip this message in the reaper until it's explicitly claimed again.
 			}
-			// Rebuild deadlines heap from current inflight map.
 			q.deadlines = q.deadlines[:0]
 			for _, dr := range q.inflight {
 				dr.heapIndex = -1
@@ -2580,7 +2578,23 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 			continue
 		}
 
-		// WAL succeeded — apply metrics.
+		// WAL succeeded — apply all pending mutations.
+		for _, p := range pending {
+			delete(q.inflight, p.dr.ReceiptHandle)
+			msg := p.msg
+			if p.targetState == StateDead {
+				msg.State = StateDead
+				q.dead[msg.ID] = msg
+			} else {
+				msg.State = StateReady
+				msg.Seq = p.newSeq
+				msg.CurrentReceiptHandle = ""
+				msg.CurrentDeliveryToken = ""
+				msg.VisibilityDeadline = time.Time{}
+				msg.readyElement = q.ready.PushBack(msg)
+			}
+		}
+
 		for _, tr := range transitions {
 			q.metrics.inFlightCount.Add(-1)
 			if tr.ToState == StateReady {

--- a/main.go
+++ b/main.go
@@ -1915,8 +1915,11 @@ type deliveryRecord struct {
 	DeliveryToken string
 	Deadline      time.Time
 	DeliveryCount int
+	seq           uint64
 	heapIndex     int // index in visibilityHeap
 }
+
+var deliveryRecordSeq atomic.Uint64
 
 // ============================================================================
 // visibilityHeap
@@ -1927,6 +1930,9 @@ type visibilityHeap []*deliveryRecord
 
 func (h visibilityHeap) Len() int { return len(h) }
 func (h visibilityHeap) Less(i, j int) bool {
+	if h[i].Deadline.Equal(h[j].Deadline) {
+		return h[i].seq < h[j].seq
+	}
 	return h[i].Deadline.Before(h[j].Deadline)
 }
 func (h visibilityHeap) Swap(i, j int) {
@@ -1962,9 +1968,9 @@ type queueRuntime struct {
 
 	nextSeq uint64
 
-	ready    *list.List                    // []*messageRecord — FIFO order
-	messages map[string]*messageRecord     // keyed by message ID
-	inflight map[string]*deliveryRecord    // keyed by receiptHandle
+	ready    *list.List                 // []*messageRecord — FIFO order
+	messages map[string]*messageRecord  // keyed by message ID
+	inflight map[string]*deliveryRecord // keyed by receiptHandle
 	dead     map[string]*messageRecord
 
 	deadlines visibilityHeap // min-heap of *deliveryRecord
@@ -2211,6 +2217,7 @@ func (qm *queueManager) ClaimBatch(ctx context.Context, queueID string, max int)
 			DeliveryToken: msg.CurrentDeliveryToken,
 			Deadline:      msg.VisibilityDeadline,
 			DeliveryCount: msg.DeliveryCount,
+			seq:           deliveryRecordSeq.Add(1),
 		}
 		q.inflight[dr.ReceiptHandle] = dr
 		heap.Push(&q.deadlines, dr)
@@ -2500,7 +2507,7 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 		}
 		var pending []pendingReap
 
-		for len(q.deadlines) > 0 && q.deadlines[0].Deadline.Before(now) {
+		for len(q.deadlines) > 0 && !q.deadlines[0].Deadline.After(now) {
 			dr := heap.Pop(&q.deadlines).(*deliveryRecord)
 			msg, ok := q.messages[dr.MessageID]
 			if !ok {
@@ -2587,15 +2594,17 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 			}
 		}
 
+		hasReadyTransition := false
 		for _, tr := range transitions {
 			q.metrics.inFlightCount.Add(-1)
 			if tr.ToState == StateReady {
 				q.metrics.readyCount.Add(1)
+				hasReadyTransition = true
 			} else {
 				q.metrics.deadCount.Add(1)
 			}
 		}
-		if len(transitions) > 0 && transitions[0].ToState == StateReady {
+		if hasReadyTransition {
 			q.signalReady()
 		}
 

--- a/main.go
+++ b/main.go
@@ -2046,3 +2046,556 @@ func (qm *queueManager) getQueue(queueID string) (*queueRuntime, error) {
 	}
 	return q, nil
 }
+
+// ============================================================================
+// CreateQueue
+// ============================================================================
+
+func (qm *queueManager) CreateQueue(ctx context.Context, name string, maxRetries int) (string, error) {
+	queueID := uuid.NewString()
+	metrics := getOrCreateMetrics(queueID)
+
+	entry := walEntry{
+		Op: opCreateQueue,
+		Payload: walCreateQueuePayload{
+			QueueID:    queueID,
+			Name:       name,
+			MaxRetries: maxRetries,
+		},
+	}
+	if _, _, err := qm.wal.Append(ctx, []walEntry{entry}); err != nil {
+		return "", fmt.Errorf("wal append create queue: %w", err)
+	}
+
+	config := QueueConfig{Name: name, MaxRetries: maxRetries}
+	q := newQueueRuntime(queueID, config, metrics)
+
+	qm.mu.Lock()
+	qm.queues[queueID] = q
+	qm.mu.Unlock()
+
+	return queueID, nil
+}
+
+// ============================================================================
+// PublishBatch
+// ============================================================================
+
+func (qm *queueManager) PublishBatch(ctx context.Context, queueID string, bodies [][]byte) ([]string, error) {
+	q, err := qm.getQueue(queueID)
+	if err != nil {
+		return nil, err
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	n := len(bodies)
+	if n == 0 {
+		return nil, nil
+	}
+
+	// Enforce memory limits.
+	if q.maxMessages > 0 && int64(len(q.messages)+n) > q.maxMessages {
+		return nil, errors.New("queue message limit exceeded")
+	}
+	var totalBytes int64
+	for _, b := range bodies {
+		totalBytes += int64(len(b))
+	}
+	if q.maxBytes > 0 && q.bytesInMem+totalBytes > q.maxBytes {
+		return nil, errors.New("queue byte limit exceeded")
+	}
+
+	// Allocate seq range.
+	startSeq := q.nextSeq
+	q.nextSeq += uint64(n)
+
+	records := make([]*messageRecord, n)
+	now := time.Now()
+	walMsgs := make([]walPublishedMessage, n)
+	ids := make([]string, n)
+
+	for i, body := range bodies {
+		msgID := uuid.NewString()
+		seq := startSeq + uint64(i)
+		msg := &messageRecord{
+			ID:               msgID,
+			QueueID:          queueID,
+			Seq:              seq,
+			Body:             bytes.Clone(body),
+			State:            StateReady,
+			EnqueuedAt:       now,
+			DeliveryCount:    0,
+			MaxDeliveryCount: q.config.MaxRetries,
+		}
+		records[i] = msg
+		walMsgs[i] = walPublishedMessage{
+			MessageID:        msgID,
+			Seq:              seq,
+			Body:             msg.Body,
+			EnqueuedAt:       now,
+			MaxDeliveryCount: msg.MaxDeliveryCount,
+		}
+		ids[i] = msgID
+	}
+
+	entry := walEntry{
+		Op: opPublishBatch,
+		Payload: walPublishBatchPayload{
+			QueueID:  queueID,
+			Messages: walMsgs,
+		},
+	}
+	if _, _, err := qm.wal.Append(ctx, []walEntry{entry}); err != nil {
+		q.nextSeq = startSeq // rollback seq allocation
+		return nil, fmt.Errorf("wal append publish batch: %w", err)
+	}
+
+	// WAL succeeded — install into memory.
+	for _, msg := range records {
+		msg.readyElement = q.ready.PushBack(msg)
+		q.messages[msg.ID] = msg
+	}
+	q.bytesInMem += totalBytes
+	q.metrics.totalPublished.Add(int64(n))
+	q.metrics.readyCount.Add(int64(n))
+	q.signalReady()
+
+	return ids, nil
+}
+
+// ============================================================================
+// ClaimBatch — O(1) list pop, not map scan
+// ============================================================================
+
+func (qm *queueManager) ClaimBatch(ctx context.Context, queueID string, max int) ([]claimedMessage, error) {
+	q, err := qm.getQueue(queueID)
+	if err != nil {
+		return nil, err
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// Pop up to max from ready list front.
+	var popped []*messageRecord
+	for i := 0; i < max; i++ {
+		front := q.ready.Front()
+		if front == nil {
+			break
+		}
+		msg := front.Value.(*messageRecord)
+		q.ready.Remove(front)
+		msg.readyElement = nil
+		popped = append(popped, msg)
+	}
+	if len(popped) == 0 {
+		return nil, ErrNoReadyMessages
+	}
+
+	now := time.Now()
+	vt := 30 * time.Second
+	claims := make([]walClaimedMessage, len(popped))
+
+	for i, msg := range popped {
+		msg.State = StateInFlight
+		msg.DeliveryCount++
+		msg.CurrentReceiptHandle = receiptHandleForMessage(queueID, msg.Seq, msg.ID)
+		msg.CurrentDeliveryToken = uuid.NewString()
+		msg.VisibilityDeadline = now.Add(vt)
+
+		dr := &deliveryRecord{
+			MessageID:     msg.ID,
+			ReceiptHandle: msg.CurrentReceiptHandle,
+			DeliveryToken: msg.CurrentDeliveryToken,
+			Deadline:      msg.VisibilityDeadline,
+			DeliveryCount: msg.DeliveryCount,
+		}
+		q.inflight[dr.ReceiptHandle] = dr
+		heap.Push(&q.deadlines, dr)
+
+		claims[i] = walClaimedMessage{
+			MessageID:          msg.ID,
+			ReceiptHandle:      dr.ReceiptHandle,
+			DeliveryToken:      dr.DeliveryToken,
+			VisibilityDeadline: msg.VisibilityDeadline,
+			DeliveryCount:      msg.DeliveryCount,
+		}
+	}
+
+	entry := walEntry{
+		Op: opClaimBatch,
+		Payload: walClaimBatchPayload{
+			QueueID: queueID,
+			Claims:  claims,
+		},
+	}
+	if _, _, err := qm.wal.Append(ctx, []walEntry{entry}); err != nil {
+		// Rollback: restore popped records to ready front in reverse order.
+		for i := len(popped) - 1; i >= 0; i-- {
+			msg := popped[i]
+			msg.State = StateReady
+			msg.CurrentReceiptHandle = ""
+			msg.CurrentDeliveryToken = ""
+			msg.VisibilityDeadline = time.Time{}
+			msg.DeliveryCount--
+			msg.readyElement = q.ready.PushFront(msg)
+			delete(q.inflight, msg.CurrentReceiptHandle)
+		}
+		// Clean up any heap entries that were added (they'll be stale but harmless
+		// until the reaper tries to process them; we'll rebuild the heap from
+		// inflight on the next operation that needs it).
+		// Simpler: rebuild the heap from the current inflight map.
+		q.deadlines = q.deadlines[:0]
+		for _, dr := range q.inflight {
+			dr.heapIndex = -1
+			heap.Push(&q.deadlines, dr)
+		}
+		return nil, fmt.Errorf("wal append claim batch: %w", err)
+	}
+
+	q.metrics.readyCount.Add(-int64(len(popped)))
+	q.metrics.inFlightCount.Add(int64(len(popped)))
+	q.metrics.totalReceived.Add(int64(len(popped)))
+
+	result := make([]claimedMessage, len(popped))
+	for i, msg := range popped {
+		result[i] = msg.toClaimedMessage()
+	}
+	return result, nil
+}
+
+func (msg *messageRecord) toClaimedMessage() claimedMessage {
+	return claimedMessage{
+		Message: Message{
+			ID:                 msg.ID,
+			Body:               msg.Body,
+			State:              msg.State,
+			EnqueuedAt:         msg.EnqueuedAt,
+			DeliveryCount:      msg.DeliveryCount,
+			MaxDeliveryCount:   msg.MaxDeliveryCount,
+			VisibilityDeadline: msg.VisibilityDeadline,
+			DeliveryAttemptID:  msg.CurrentDeliveryToken,
+		},
+		ReceiptHandle: msg.CurrentReceiptHandle,
+	}
+}
+
+// ============================================================================
+// AckBatch
+// ============================================================================
+
+type runtimeAckResult struct {
+	ReceiptHandle string
+	Status        string // "ok" or "error"
+	Error         string
+}
+
+func (qm *queueManager) AckBatch(ctx context.Context, queueID string, acks []AckEntry) []runtimeAckResult {
+	q, err := qm.getQueue(queueID)
+	if err != nil {
+		results := make([]runtimeAckResult, len(acks))
+		for i := range acks {
+			results[i] = runtimeAckResult{
+				ReceiptHandle: acks[i].ReceiptHandle,
+				Status:        "error",
+				Error:         err.Error(),
+			}
+		}
+		return results
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// Validate each entry and collect valid ones for WAL.
+	valid := make([]*deliveryRecord, 0, len(acks))
+	results := make([]runtimeAckResult, len(acks))
+	for i, entry := range acks {
+		results[i].ReceiptHandle = entry.ReceiptHandle
+		dr, ok := q.inflight[entry.ReceiptHandle]
+		if !ok {
+			results[i].Status = "error"
+			results[i].Error = "receipt handle not found"
+			continue
+		}
+		if dr.DeliveryToken != entry.DeliveryToken {
+			results[i].Status = "error"
+			results[i].Error = (&ErrDeliveryTokenMismatch{Expected: dr.DeliveryToken, Got: entry.DeliveryToken}).Error()
+			continue
+		}
+		valid = append(valid, dr)
+		results[i].Status = "ok"
+	}
+
+	if len(valid) == 0 {
+		return results
+	}
+
+	walAcks := make([]walAckedMessage, len(valid))
+	for i, dr := range valid {
+		walAcks[i] = walAckedMessage{
+			MessageID:     dr.MessageID,
+			ReceiptHandle: dr.ReceiptHandle,
+			DeliveryToken: dr.DeliveryToken,
+		}
+	}
+	entry := walEntry{
+		Op: opAckBatch,
+		Payload: walAckBatchPayload{
+			QueueID: queueID,
+			Acks:    walAcks,
+		},
+	}
+	if _, _, err := qm.wal.Append(ctx, []walEntry{entry}); err != nil {
+		for i := range results {
+			results[i].Status = "error"
+			results[i].Error = "wal append failed: " + err.Error()
+		}
+		return results
+	}
+
+	// WAL succeeded — remove from memory.
+	for _, dr := range valid {
+		if dr.heapIndex >= 0 && dr.heapIndex < len(q.deadlines) {
+			heap.Remove(&q.deadlines, dr.heapIndex)
+		}
+		delete(q.inflight, dr.ReceiptHandle)
+		delete(q.messages, dr.MessageID)
+	}
+	q.metrics.inFlightCount.Add(-int64(len(valid)))
+	q.metrics.totalAcked.Add(int64(len(valid)))
+	q.metrics.ackCountWindow.Add(int64(len(valid)))
+
+	return results
+}
+
+// ============================================================================
+// Nack
+// ============================================================================
+
+func (qm *queueManager) Nack(ctx context.Context, queueID, receiptHandle, deliveryToken string) (MessageState, error) {
+	q, err := qm.getQueue(queueID)
+	if err != nil {
+		return "", err
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	dr, ok := q.inflight[receiptHandle]
+	if !ok {
+		return "", &ErrInvalidReceiptHandle{Reason: "receipt handle not found"}
+	}
+	if dr.DeliveryToken != deliveryToken {
+		return "", &ErrDeliveryTokenMismatch{Expected: dr.DeliveryToken, Got: deliveryToken}
+	}
+
+	msg, ok := q.messages[dr.MessageID]
+	if !ok {
+		return "", errors.New("message not found")
+	}
+
+	// Remove from inflight and deadlines.
+	if dr.heapIndex >= 0 && dr.heapIndex < len(q.deadlines) {
+		heap.Remove(&q.deadlines, dr.heapIndex)
+	}
+	delete(q.inflight, receiptHandle)
+
+	// Determine target state.
+	var targetState MessageState
+	var newSeq uint64
+	if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
+		targetState = StateDead
+		msg.State = StateDead
+		q.dead[msg.ID] = msg
+	} else {
+		targetState = StateReady
+		msg.State = StateReady
+		newSeq = q.nextSeq
+		q.nextSeq++
+		msg.Seq = newSeq
+		msg.CurrentReceiptHandle = ""
+		msg.CurrentDeliveryToken = ""
+		msg.VisibilityDeadline = time.Time{}
+		msg.readyElement = q.ready.PushBack(msg)
+	}
+
+	walEntryVal := walEntry{
+		Op: opNack,
+		Payload: walNackPayload{
+			QueueID:        queueID,
+			MessageID:      msg.ID,
+			ReceiptHandle:  dr.ReceiptHandle,
+			DeliveryToken:  dr.DeliveryToken,
+			TargetState:    targetState,
+			HasNewReadySeq: targetState == StateReady,
+			NewReadySeq:    newSeq,
+		},
+	}
+	if _, _, err := qm.wal.Append(ctx, []walEntry{walEntryVal}); err != nil {
+		// Rollback: restore delivery record.
+		q.inflight[receiptHandle] = dr
+		dr.heapIndex = -1
+		heap.Push(&q.deadlines, dr)
+		if targetState == StateReady {
+			q.ready.Remove(msg.readyElement)
+			msg.readyElement = nil
+			msg.State = StateInFlight
+			msg.CurrentReceiptHandle = dr.ReceiptHandle
+			msg.CurrentDeliveryToken = dr.DeliveryToken
+			msg.VisibilityDeadline = dr.Deadline
+			q.nextSeq = newSeq
+		} else {
+			delete(q.dead, msg.ID)
+			msg.State = StateInFlight
+		}
+		return "", fmt.Errorf("wal append nack: %w", err)
+	}
+
+	q.metrics.inFlightCount.Add(-1)
+	if targetState == StateReady {
+		q.metrics.readyCount.Add(1)
+		q.signalReady()
+	} else {
+		q.metrics.deadCount.Add(1)
+	}
+
+	return targetState, nil
+}
+
+// ============================================================================
+// ReapExpired — deadline heap peek, not full scan
+// ============================================================================
+
+func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTransition {
+	qm.mu.RLock()
+	ids := make([]string, 0, len(qm.queues))
+	for id := range qm.queues {
+		ids = append(ids, id)
+	}
+	qm.mu.RUnlock()
+
+	var allTransitions []reapTransition
+
+	for _, queueID := range ids {
+		q, err := qm.getQueue(queueID)
+		if err != nil {
+			continue
+		}
+
+		q.mu.Lock()
+		var transitions []reapTransition
+		var reaps []walReapedMessage
+
+		for len(q.deadlines) > 0 && q.deadlines[0].Deadline.Before(now) {
+			dr := heap.Pop(&q.deadlines).(*deliveryRecord)
+			msg, ok := q.messages[dr.MessageID]
+			if !ok {
+				continue
+			}
+			if msg.State != StateInFlight {
+				continue
+			}
+			// Guard against stale heap entries (token changed since push).
+			if msg.CurrentDeliveryToken != dr.DeliveryToken {
+				continue
+			}
+			if msg.VisibilityDeadline.After(now) {
+				// Should not happen because heap ordering, but guard.
+				continue
+			}
+
+			// Remove from inflight.
+			delete(q.inflight, dr.ReceiptHandle)
+
+			var targetState MessageState
+			var newSeq uint64
+			if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
+				targetState = StateDead
+				msg.State = StateDead
+				q.dead[msg.ID] = msg
+			} else {
+				targetState = StateReady
+				msg.State = StateReady
+				newSeq = q.nextSeq
+				q.nextSeq++
+				msg.Seq = newSeq
+				msg.CurrentReceiptHandle = ""
+				msg.CurrentDeliveryToken = ""
+				msg.VisibilityDeadline = time.Time{}
+				msg.readyElement = q.ready.PushBack(msg)
+			}
+
+			reaps = append(reaps, walReapedMessage{
+				MessageID:             msg.ID,
+				PreviousDeliveryToken: dr.DeliveryToken,
+				TargetState:           targetState,
+				HasNewReadySeq:        targetState == StateReady,
+				NewReadySeq:           newSeq,
+			})
+			transitions = append(transitions, reapTransition{QueueID: queueID, ToState: targetState})
+		}
+
+		if len(reaps) == 0 {
+			q.mu.Unlock()
+			continue
+		}
+
+		entry := walEntry{
+			Op: opReapBatch,
+			Payload: walReapBatchPayload{
+				QueueID: queueID,
+				Reaps:   reaps,
+			},
+		}
+		if _, _, err := qm.wal.Append(ctx, []walEntry{entry}); err != nil {
+			// Rollback: restore all transitioned messages to inflight.
+			for _, tr := range reaps {
+				msg := q.messages[tr.MessageID]
+				if msg == nil {
+					continue
+				}
+				if tr.TargetState == StateReady {
+					q.ready.Remove(msg.readyElement)
+					msg.readyElement = nil
+					q.nextSeq = tr.NewReadySeq
+				} else {
+					delete(q.dead, msg.ID)
+				}
+				msg.State = StateInFlight
+				msg.Seq = 0 // we don't restore seq; it'll be set correctly on next claim
+				// Rebuild receipt handle and token from the original delivery record
+				// is impossible here, so we rebuild the heap from current inflight map
+				// and skip this message in the reaper until it's explicitly claimed again.
+			}
+			// Rebuild deadlines heap from current inflight map.
+			q.deadlines = q.deadlines[:0]
+			for _, dr := range q.inflight {
+				dr.heapIndex = -1
+				heap.Push(&q.deadlines, dr)
+			}
+			q.mu.Unlock()
+			continue
+		}
+
+		// WAL succeeded — apply metrics.
+		for _, tr := range transitions {
+			q.metrics.inFlightCount.Add(-1)
+			if tr.ToState == StateReady {
+				q.metrics.readyCount.Add(1)
+			} else {
+				q.metrics.deadCount.Add(1)
+			}
+		}
+		if len(transitions) > 0 && transitions[0].ToState == StateReady {
+			q.signalReady()
+		}
+
+		allTransitions = append(allTransitions, transitions...)
+		q.mu.Unlock()
+	}
+
+	return allTransitions
+}

--- a/main.go
+++ b/main.go
@@ -2405,7 +2405,6 @@ func (qm *queueManager) Nack(ctx context.Context, queueID, receiptHandle, delive
 
 	// Determine target state.
 	var targetState MessageState
-	var newSeq uint64
 	if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
 		targetState = StateDead
 		msg.State = StateDead
@@ -2413,9 +2412,6 @@ func (qm *queueManager) Nack(ctx context.Context, queueID, receiptHandle, delive
 	} else {
 		targetState = StateReady
 		msg.State = StateReady
-		newSeq = q.nextSeq
-		q.nextSeq++
-		msg.Seq = newSeq
 		msg.CurrentReceiptHandle = ""
 		msg.CurrentDeliveryToken = ""
 		msg.VisibilityDeadline = time.Time{}
@@ -2430,8 +2426,8 @@ func (qm *queueManager) Nack(ctx context.Context, queueID, receiptHandle, delive
 			ReceiptHandle:  dr.ReceiptHandle,
 			DeliveryToken:  dr.DeliveryToken,
 			TargetState:    targetState,
-			HasNewReadySeq: targetState == StateReady,
-			NewReadySeq:    newSeq,
+			HasNewReadySeq: false,
+			NewReadySeq:    0,
 		},
 	}
 	if _, _, err := qm.wal.Append(ctx, []walEntry{walEntryVal}); err != nil {
@@ -2446,7 +2442,6 @@ func (qm *queueManager) Nack(ctx context.Context, queueID, receiptHandle, delive
 			msg.CurrentReceiptHandle = dr.ReceiptHandle
 			msg.CurrentDeliveryToken = dr.DeliveryToken
 			msg.VisibilityDeadline = dr.Deadline
-			q.nextSeq = newSeq
 		} else {
 			delete(q.dead, msg.ID)
 			msg.State = StateInFlight
@@ -2494,7 +2489,6 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 			dr          *deliveryRecord
 			msg         *messageRecord
 			targetState MessageState
-			newSeq      uint64
 		}
 		var pending []pendingReap
 
@@ -2515,28 +2509,24 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 			}
 
 			var targetState MessageState
-			var newSeq uint64
 			if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
 				targetState = StateDead
 			} else {
 				targetState = StateReady
-				newSeq = q.nextSeq
-				q.nextSeq++
 			}
 
 			pending = append(pending, pendingReap{
 				dr:          dr,
 				msg:         msg,
 				targetState: targetState,
-				newSeq:      newSeq,
 			})
 
 			reaps = append(reaps, walReapedMessage{
 				MessageID:             msg.ID,
 				PreviousDeliveryToken: dr.DeliveryToken,
 				TargetState:           targetState,
-				HasNewReadySeq:        targetState == StateReady,
-				NewReadySeq:           newSeq,
+				HasNewReadySeq:        false,
+				NewReadySeq:           0,
 			})
 			transitions = append(transitions, reapTransition{QueueID: queueID, ToState: targetState})
 		}
@@ -2563,12 +2553,7 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 		if _, _, err := qm.wal.Append(ctx, []walEntry{entry}); err != nil {
 			// WAL failed — no mutations were applied. The delivery records
 			// are still in q.inflight. Rebuild the heap from the inflight
-			// map (which is unchanged) and rollback seq allocations.
-			for _, p := range pending {
-				if p.targetState == StateReady {
-					q.nextSeq-- // rollback seq allocation
-				}
-			}
+			// map (which is unchanged).
 			q.deadlines = q.deadlines[:0]
 			for _, dr := range q.inflight {
 				dr.heapIndex = -1
@@ -2587,7 +2572,6 @@ func (qm *queueManager) ReapExpired(ctx context.Context, now time.Time) []reapTr
 				q.dead[msg.ID] = msg
 			} else {
 				msg.State = StateReady
-				msg.Seq = p.newSeq
 				msg.CurrentReceiptHandle = ""
 				msg.CurrentDeliveryToken = ""
 				msg.VisibilityDeadline = time.Time{}

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"bytes"
+	"container/heap"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -1431,5 +1434,633 @@ func TestBatchReceiveLongPollWithWait(t *testing.T) {
 	// FIFO: first published should be first received
 	if string(resp.Messages[0].Body) != "batch-0" {
 		t.Fatalf("first message body = %q, want batch-0", string(resp.Messages[0].Body))
+	}
+}
+
+// ============================================================================
+// Phase 2.2: queueRuntime test harness
+// ============================================================================
+
+type fakeWAL struct {
+	mu      sync.Mutex
+	entries []walEntry
+	nextLSN uint64
+	fail    bool
+}
+
+func (f *fakeWAL) Append(ctx context.Context, entries []walEntry) (uint64, uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fail {
+		return 0, 0, errors.New("fake WAL failure")
+	}
+	first := f.nextLSN
+	if f.nextLSN == 0 {
+		f.nextLSN = 1
+		first = 1
+	}
+	for i := range entries {
+		f.nextLSN++
+		entries[i].LSN = f.nextLSN
+		f.entries = append(f.entries, entries[i])
+	}
+	return first, f.nextLSN, nil
+}
+
+func setupRuntimeTest(t *testing.T) (*queueManager, *fakeWAL) {
+	t.Helper()
+	wal := &fakeWAL{}
+	qm := newQueueManager(wal)
+	return qm, wal
+}
+
+// ============================================================================
+// T1: CreateQueue
+// ============================================================================
+
+func TestRuntimeCreateQueue(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, err := qm.CreateQueue(ctx, "test-queue", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected non-empty queue ID")
+	}
+
+	q, err := qm.getQueue(id)
+	if err != nil {
+		t.Fatalf("get queue: %v", err)
+	}
+	if q.config.Name != "test-queue" {
+		t.Fatalf("queue name = %q, want test-queue", q.config.Name)
+	}
+	if q.config.MaxRetries != 3 {
+		t.Fatalf("maxRetries = %d, want 3", q.config.MaxRetries)
+	}
+}
+
+// ============================================================================
+// T2: PublishBatch FIFO
+// ============================================================================
+
+func TestRuntimePublishBatchFIFO(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "fifo", 3)
+	bodies := [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d"), []byte("e")}
+	_, err := qm.PublishBatch(ctx, id, bodies)
+	if err != nil {
+		t.Fatalf("publish batch: %v", err)
+	}
+
+	claimed, err := qm.ClaimBatch(ctx, id, 5)
+	if err != nil {
+		t.Fatalf("claim batch: %v", err)
+	}
+	if len(claimed) != 5 {
+		t.Fatalf("claimed %d, want 5", len(claimed))
+	}
+	for i, msg := range claimed {
+		want := bodies[i]
+		if !bytes.Equal(msg.Body, want) {
+			t.Fatalf("message %d body = %q, want %q", i, msg.Body, want)
+		}
+	}
+}
+
+// ============================================================================
+// T3: Claim empty queue
+// ============================================================================
+
+func TestRuntimeClaimEmptyQueue(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "empty", 3)
+	_, err := qm.ClaimBatch(ctx, id, 1)
+	if !errors.Is(err, ErrNoReadyMessages) {
+		t.Fatalf("expected ErrNoReadyMessages, got %v", err)
+	}
+}
+
+// ============================================================================
+// T4: ClaimBatch respects max
+// ============================================================================
+
+func TestRuntimeClaimBatchMax(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "max-test", 3)
+	bodies := make([][]byte, 10)
+	for i := range bodies {
+		bodies[i] = []byte(fmt.Sprintf("msg-%d", i))
+	}
+	_, err := qm.PublishBatch(ctx, id, bodies)
+	if err != nil {
+		t.Fatalf("publish batch: %v", err)
+	}
+
+	claimed, err := qm.ClaimBatch(ctx, id, 3)
+	if err != nil {
+		t.Fatalf("claim batch: %v", err)
+	}
+	if len(claimed) != 3 {
+		t.Fatalf("claimed %d, want 3", len(claimed))
+	}
+
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	readyCount := q.ready.Len()
+	q.mu.Unlock()
+	if readyCount != 7 {
+		t.Fatalf("ready count = %d, want 7", readyCount)
+	}
+}
+
+// ============================================================================
+// T5: Ack removes from state
+// ============================================================================
+
+func TestRuntimeAckRemovesFromState(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "ack-test", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatal("expected 1 claimed message")
+	}
+
+	results := qm.AckBatch(ctx, id, []AckEntry{
+		{ReceiptHandle: claimed[0].ReceiptHandle, DeliveryToken: claimed[0].DeliveryAttemptID},
+	})
+	if len(results) != 1 || results[0].Status != "ok" {
+		t.Fatalf("ack result = %+v", results)
+	}
+
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	if len(q.messages) != 0 {
+		t.Fatalf("messages len = %d, want 0", len(q.messages))
+	}
+	if len(q.inflight) != 0 {
+		t.Fatalf("inflight len = %d, want 0", len(q.inflight))
+	}
+	if q.deadlines.Len() != 0 {
+		t.Fatalf("deadlines len = %d, want 0", q.deadlines.Len())
+	}
+	q.mu.Unlock()
+}
+
+// ============================================================================
+// T6: Nack returns to ready
+// ============================================================================
+
+func TestRuntimeNackReturnsToReady(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "nack-test", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	_, err = qm.Nack(ctx, id, claimed[0].ReceiptHandle, claimed[0].DeliveryAttemptID)
+	if err != nil {
+		t.Fatalf("nack: %v", err)
+	}
+
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	readyCount := q.ready.Len()
+	q.mu.Unlock()
+	if readyCount != 1 {
+		t.Fatalf("ready count after nack = %d, want 1", readyCount)
+	}
+
+	// Should be receivable again.
+	claimed2, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("reclaim after nack: %v", err)
+	}
+	if !bytes.Equal(claimed2[0].Body, []byte("hello")) {
+		t.Fatalf("reclaimed body = %q, want hello", claimed2[0].Body)
+	}
+}
+
+// ============================================================================
+// T7: Nack appends to ready tail
+// ============================================================================
+
+func TestRuntimeNackToReadyTail(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "tail-test", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("A"), []byte("B")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	claimed, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if string(claimed[0].Body) != "A" {
+		t.Fatalf("first claim = %q, want A", claimed[0].Body)
+	}
+
+	_, err = qm.Nack(ctx, id, claimed[0].ReceiptHandle, claimed[0].DeliveryAttemptID)
+	if err != nil {
+		t.Fatalf("nack: %v", err)
+	}
+
+	claimed2, err := qm.ClaimBatch(ctx, id, 2)
+	if err != nil {
+		t.Fatalf("claim 2: %v", err)
+	}
+	if len(claimed2) != 2 {
+		t.Fatalf("claimed %d, want 2", len(claimed2))
+	}
+	if string(claimed2[0].Body) != "B" {
+		t.Fatalf("first after nack = %q, want B", claimed2[0].Body)
+	}
+	if string(claimed2[1].Body) != "A" {
+		t.Fatalf("second after nack = %q, want A", claimed2[1].Body)
+	}
+}
+
+// ============================================================================
+// T8: Dead letter after max deliveries via nack
+// ============================================================================
+
+func TestRuntimeDeadLetterAfterMaxDeliveries(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "dead-test", 1)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if claimed[0].DeliveryCount != 1 {
+		t.Fatalf("delivery count = %d, want 1", claimed[0].DeliveryCount)
+	}
+
+	state, err := qm.Nack(ctx, id, claimed[0].ReceiptHandle, claimed[0].DeliveryAttemptID)
+	if err != nil {
+		t.Fatalf("nack: %v", err)
+	}
+	if state != StateDead {
+		t.Fatalf("state = %q, want dead", state)
+	}
+
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	deadCount := len(q.dead)
+	q.mu.Unlock()
+	if deadCount != 1 {
+		t.Fatalf("dead count = %d, want 1", deadCount)
+	}
+
+	// Should NOT be receivable.
+	_, err = qm.ClaimBatch(ctx, id, 1)
+	if !errors.Is(err, ErrNoReadyMessages) {
+		t.Fatalf("expected ErrNoReadyMessages after dead letter, got %v", err)
+	}
+}
+
+// ============================================================================
+// T9: Stale ack token rejected after redelivery
+// ============================================================================
+
+func TestRuntimeStaleAckRejected(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "stale-test", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	oldToken := claimed[0].DeliveryAttemptID
+
+	_, err = qm.Nack(ctx, id, claimed[0].ReceiptHandle, oldToken)
+	if err != nil {
+		t.Fatalf("nack: %v", err)
+	}
+
+	claimed2, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if claimed2[0].DeliveryAttemptID == oldToken {
+		t.Fatal("expected new delivery token after redelivery")
+	}
+
+	results := qm.AckBatch(ctx, id, []AckEntry{
+		{ReceiptHandle: claimed2[0].ReceiptHandle, DeliveryToken: oldToken},
+	})
+	if len(results) != 1 || results[0].Status != "error" {
+		t.Fatalf("expected stale ack rejected, got %+v", results)
+	}
+}
+
+// ============================================================================
+// T10: Reap expired to ready
+// ============================================================================
+
+func TestRuntimeReapExpiredToReady(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "reap-ready", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	_, err = qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	// Manually expire the message.
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	for _, msg := range q.messages {
+		msg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
+	}
+	// Rebuild deadlines heap with the new deadline.
+	q.deadlines = q.deadlines[:0]
+	for _, dr := range q.inflight {
+		dr.heapIndex = -1
+		dr.Deadline = time.Now().Add(-1 * time.Second)
+		heap.Push(&q.deadlines, dr)
+	}
+	q.mu.Unlock()
+
+	transitions := qm.ReapExpired(ctx, time.Now())
+	if len(transitions) != 1 {
+		t.Fatalf("reap transitions = %d, want 1", len(transitions))
+	}
+	if transitions[0].ToState != StateReady {
+		t.Fatalf("reap toState = %q, want ready", transitions[0].ToState)
+	}
+
+	// Should be receivable again.
+	claimed2, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("reclaim after reap: %v", err)
+	}
+	if !bytes.Equal(claimed2[0].Body, []byte("hello")) {
+		t.Fatalf("reclaimed body = %q, want hello", claimed2[0].Body)
+	}
+}
+
+// ============================================================================
+// T11: Reap dead letter
+// ============================================================================
+
+func TestRuntimeReapDeadLetter(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "reap-dead", 1)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	_, err = qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	for _, msg := range q.messages {
+		msg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
+	}
+	q.deadlines = q.deadlines[:0]
+	for _, dr := range q.inflight {
+		dr.heapIndex = -1
+		dr.Deadline = time.Now().Add(-1 * time.Second)
+		heap.Push(&q.deadlines, dr)
+	}
+	q.mu.Unlock()
+
+	transitions := qm.ReapExpired(ctx, time.Now())
+	if len(transitions) != 1 {
+		t.Fatalf("reap transitions = %d, want 1", len(transitions))
+	}
+	if transitions[0].ToState != StateDead {
+		t.Fatalf("reap toState = %q, want dead", transitions[0].ToState)
+	}
+
+	q.mu.Lock()
+	deadCount := len(q.dead)
+	q.mu.Unlock()
+	if deadCount != 1 {
+		t.Fatalf("dead count = %d, want 1", deadCount)
+	}
+}
+
+// ============================================================================
+// T12: Concurrent queues do not block each other
+// ============================================================================
+
+func TestRuntimeConcurrentQueuesDontBlock(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id1, _ := qm.CreateQueue(ctx, "q1", 3)
+	id2, _ := qm.CreateQueue(ctx, "q2", 3)
+
+	_, err := qm.PublishBatch(ctx, id1, [][]byte{[]byte("a")})
+	if err != nil {
+		t.Fatalf("publish q1: %v", err)
+	}
+	_, err = qm.PublishBatch(ctx, id2, [][]byte{[]byte("b")})
+	if err != nil {
+		t.Fatalf("publish q2: %v", err)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var got1, got2 []claimedMessage
+	go func() {
+		defer wg.Done()
+		<-start
+		var err1 error
+		got1, err1 = qm.ClaimBatch(ctx, id1, 1)
+		if err1 != nil {
+			t.Errorf("claim q1: %v", err1)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		var err2 error
+		got2, err2 = qm.ClaimBatch(ctx, id2, 1)
+		if err2 != nil {
+			t.Errorf("claim q2: %v", err2)
+		}
+	}()
+
+	close(start)
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent claims blocked — possible global mutex contention")
+	}
+
+	if len(got1) != 1 || string(got1[0].Body) != "a" {
+		t.Fatalf("q1 claim wrong: %+v", got1)
+	}
+	if len(got2) != 1 || string(got2[0].Body) != "b" {
+		t.Fatalf("q2 claim wrong: %+v", got2)
+	}
+}
+
+// ============================================================================
+// T13: WAL append is called
+// ============================================================================
+
+func TestRuntimeWALAppendCalled(t *testing.T) {
+	qm, wal := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "wal-test", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	wal.mu.Lock()
+	count := len(wal.entries)
+	wal.mu.Unlock()
+	if count < 2 {
+		t.Fatalf("expected at least 2 WAL entries (create + publish), got %d", count)
+	}
+
+	var hasCreate, hasPublish bool
+	wal.mu.Lock()
+	for _, e := range wal.entries {
+		switch e.Op {
+		case opCreateQueue:
+			hasCreate = true
+		case opPublishBatch:
+			hasPublish = true
+		}
+	}
+	wal.mu.Unlock()
+	if !hasCreate {
+		t.Fatal("missing opCreateQueue in WAL")
+	}
+	if !hasPublish {
+		t.Fatal("missing opPublishBatch in WAL")
+	}
+}
+
+// ============================================================================
+// T14: WAL failure rolls back memory state
+// ============================================================================
+
+func TestRuntimeWALFailureRollsBack(t *testing.T) {
+	qm, wal := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "rollback-test", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	beforeReady := q.ready.Len()
+	beforeNextSeq := q.nextSeq
+	q.mu.Unlock()
+	if beforeReady != 1 {
+		t.Fatalf("ready before = %d, want 1", beforeReady)
+	}
+
+	wal.fail = true
+	_, err = qm.PublishBatch(ctx, id, [][]byte{[]byte("world")})
+	if err == nil {
+		t.Fatal("expected WAL failure error")
+	}
+
+	q.mu.Lock()
+	afterReady := q.ready.Len()
+	afterNextSeq := q.nextSeq
+	q.mu.Unlock()
+	if afterReady != beforeReady {
+		t.Fatalf("ready after rollback = %d, want %d", afterReady, beforeReady)
+	}
+	if afterNextSeq != beforeNextSeq {
+		t.Fatalf("nextSeq after rollback = %d, want %d", afterNextSeq, beforeNextSeq)
+	}
+}
+
+// ============================================================================
+// T15: Memory limit rejects publish
+// ============================================================================
+
+func TestRuntimeMemoryLimitReject(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "limit-test", 3)
+	q, _ := qm.getQueue(id)
+	q.maxMessages = 1
+
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("first")})
+	if err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+
+	_, err = qm.PublishBatch(ctx, id, [][]byte{[]byte("second")})
+	if err == nil {
+		t.Fatal("expected memory limit error")
+	}
+
+	q.mu.Lock()
+	readyCount := q.ready.Len()
+	q.mu.Unlock()
+	if readyCount != 1 {
+		t.Fatalf("ready count = %d, want 1", readyCount)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1783,11 +1784,18 @@ func TestRuntimeStaleAckRejected(t *testing.T) {
 		t.Fatal("expected new delivery token after redelivery")
 	}
 
+	// Using the old token with the current receipt handle should yield
+	// a delivery token mismatch, not "receipt handle not found".
+	// Seq is now immutable across redeliveries, so the receipt handle
+	// stays the same and the inflight lookup succeeds.
 	results := qm.AckBatch(ctx, id, []AckEntry{
 		{ReceiptHandle: claimed2[0].ReceiptHandle, DeliveryToken: oldToken},
 	})
 	if len(results) != 1 || results[0].Status != "error" {
 		t.Fatalf("expected stale ack rejected, got %+v", results)
+	}
+	if !strings.Contains(results[0].Error, "delivery token mismatch") {
+		t.Fatalf("expected delivery token mismatch error, got: %s", results[0].Error)
 	}
 }
 
@@ -1839,6 +1847,37 @@ func TestRuntimeReapExpiredToReady(t *testing.T) {
 	}
 	if !bytes.Equal(claimed2[0].Body, []byte("hello")) {
 		t.Fatalf("reclaimed body = %q, want hello", claimed2[0].Body)
+	}
+}
+
+// T9b: Receipt handle is preserved across redeliveries
+func TestRuntimeReceiptHandlePreservedAcrossRedelivery(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "rh-preserve", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	firstRH := claimed[0].ReceiptHandle
+
+	_, err = qm.Nack(ctx, id, claimed[0].ReceiptHandle, claimed[0].DeliveryAttemptID)
+	if err != nil {
+		t.Fatalf("nack: %v", err)
+	}
+
+	claimed2, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	// Receipt handle must be the same after redelivery because Seq is immutable.
+	if claimed2[0].ReceiptHandle != firstRH {
+		t.Fatalf("receipt handle changed after redelivery: got %q, want %q", claimed2[0].ReceiptHandle, firstRH)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1443,13 +1443,19 @@ func TestBatchReceiveLongPollWithWait(t *testing.T) {
 // ============================================================================
 
 type fakeWAL struct {
-	mu      sync.Mutex
-	entries []walEntry
-	nextLSN uint64
-	fail    bool
+	mu           sync.Mutex
+	entries      []walEntry
+	nextLSN      uint64
+	fail         bool
+	beforeAppend func(context.Context, []walEntry) error
 }
 
 func (f *fakeWAL) Append(ctx context.Context, entries []walEntry) (uint64, uint64, error) {
+	if f.beforeAppend != nil {
+		if err := f.beforeAppend(ctx, entries); err != nil {
+			return 0, 0, err
+		}
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.fail {
@@ -1473,6 +1479,26 @@ func setupRuntimeTest(t *testing.T) (*queueManager, *fakeWAL) {
 	wal := &fakeWAL{}
 	qm := newQueueManager(wal)
 	return qm, wal
+}
+
+func TestFakeWALAppendStoresReturnedLSNs(t *testing.T) {
+	wal := &fakeWAL{}
+	first, last, err := wal.Append(context.Background(), []walEntry{
+		{Op: opCreateQueue, Payload: walCreateQueuePayload{QueueID: "q1", Name: "one"}},
+		{Op: opCreateQueue, Payload: walCreateQueuePayload{QueueID: "q2", Name: "two"}},
+	})
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if first != 1 || last != 2 {
+		t.Fatalf("first,last = %d,%d; want 1,2", first, last)
+	}
+	if len(wal.entries) != 2 {
+		t.Fatalf("stored entries = %d, want 2", len(wal.entries))
+	}
+	if wal.entries[0].LSN != 1 || wal.entries[1].LSN != 2 {
+		t.Fatalf("stored LSNs = %d,%d; want 1,2", wal.entries[0].LSN, wal.entries[1].LSN)
+	}
 }
 
 // ============================================================================
@@ -1850,6 +1876,43 @@ func TestRuntimeReapExpiredToReady(t *testing.T) {
 	}
 }
 
+func TestRuntimeReapDeadlineEqualNowIsExpired(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "reap-equal-now", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	_, err = qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	now := time.Now()
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	for _, msg := range q.messages {
+		msg.VisibilityDeadline = now
+	}
+	q.deadlines = q.deadlines[:0]
+	for _, dr := range q.inflight {
+		dr.heapIndex = -1
+		dr.Deadline = now
+		heap.Push(&q.deadlines, dr)
+	}
+	q.mu.Unlock()
+
+	transitions := qm.ReapExpired(ctx, now)
+	if len(transitions) != 1 {
+		t.Fatalf("reap transitions = %d, want 1", len(transitions))
+	}
+	if transitions[0].ToState != StateReady {
+		t.Fatalf("reap toState = %q, want ready", transitions[0].ToState)
+	}
+}
+
 // T9b: Receipt handle is preserved across redeliveries
 func TestRuntimeReceiptHandlePreservedAcrossRedelivery(t *testing.T) {
 	qm, _ := setupRuntimeTest(t)
@@ -1933,7 +1996,7 @@ func TestRuntimeReapDeadLetter(t *testing.T) {
 // ============================================================================
 
 func TestRuntimeConcurrentQueuesDontBlock(t *testing.T) {
-	qm, _ := setupRuntimeTest(t)
+	qm, wal := setupRuntimeTest(t)
 	ctx := context.Background()
 
 	id1, _ := qm.CreateQueue(ctx, "q1", 3)
@@ -1948,41 +2011,68 @@ func TestRuntimeConcurrentQueuesDontBlock(t *testing.T) {
 		t.Fatalf("publish q2: %v", err)
 	}
 
-	start := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(2)
+	blockEntered := make(chan struct{})
+	releaseBlock := make(chan struct{})
+	var blockOnce sync.Once
+	wal.beforeAppend = func(ctx context.Context, entries []walEntry) error {
+		if len(entries) == 0 || entries[0].Op != opClaimBatch {
+			return nil
+		}
+		payload, ok := entries[0].Payload.(walClaimBatchPayload)
+		if !ok || payload.QueueID != id1 {
+			return nil
+		}
+		blockOnce.Do(func() {
+			close(blockEntered)
+		})
+		select {
+		case <-releaseBlock:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 
-	var got1, got2 []claimedMessage
+	var got1 []claimedMessage
+	q1Done := make(chan error, 1)
 	go func() {
-		defer wg.Done()
-		<-start
 		var err1 error
 		got1, err1 = qm.ClaimBatch(ctx, id1, 1)
-		if err1 != nil {
-			t.Errorf("claim q1: %v", err1)
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		<-start
-		var err2 error
-		got2, err2 = qm.ClaimBatch(ctx, id2, 1)
-		if err2 != nil {
-			t.Errorf("claim q2: %v", err2)
-		}
-	}()
-
-	close(start)
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
+		q1Done <- err1
 	}()
 
 	select {
-	case <-done:
+	case <-blockEntered:
 	case <-time.After(2 * time.Second):
-		t.Fatal("concurrent claims blocked — possible global mutex contention")
+		t.Fatal("q1 claim did not reach blocked WAL append")
+	}
+
+	var got2 []claimedMessage
+	q2Done := make(chan error, 1)
+	go func() {
+		var err2 error
+		got2, err2 = qm.ClaimBatch(ctx, id2, 1)
+		q2Done <- err2
+	}()
+
+	select {
+	case err := <-q2Done:
+		if err != nil {
+			t.Fatalf("claim q2: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		close(releaseBlock)
+		t.Fatal("q2 claim blocked behind q1 claim")
+	}
+
+	close(releaseBlock)
+	select {
+	case err := <-q1Done:
+		if err != nil {
+			t.Fatalf("claim q1: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("q1 claim did not finish after unblocking WAL")
 	}
 
 	if len(got1) != 1 || string(got1[0].Body) != "a" {
@@ -1990,6 +2080,35 @@ func TestRuntimeConcurrentQueuesDontBlock(t *testing.T) {
 	}
 	if len(got2) != 1 || string(got2[0].Body) != "b" {
 		t.Fatalf("q2 claim wrong: %+v", got2)
+	}
+}
+
+func TestRuntimeVisibilityHeapOrdersEqualDeadlinesByClaimOrder(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "equal-deadlines", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("a"), []byte("b"), []byte("c")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm.ClaimBatch(ctx, id, 3)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	got := make([]string, 0, 3)
+	for q.deadlines.Len() > 0 {
+		dr := heap.Pop(&q.deadlines).(*deliveryRecord)
+		got = append(got, dr.ReceiptHandle)
+	}
+	want := []string{claimed[0].ReceiptHandle, claimed[1].ReceiptHandle, claimed[2].ReceiptHandle}
+	if !slicesEqual(got, want) {
+		t.Fatalf("heap pop order = %v, want %v", got, want)
 	}
 }
 
@@ -2339,4 +2458,78 @@ func TestRuntimeClaimWALFailNoStaleInflight(t *testing.T) {
 	if len(claimed) != 2 {
 		t.Fatalf("claimed %d messages, want 2", len(claimed))
 	}
+}
+
+func TestRuntimeReapSignalsWhenAnyTransitionReturnsReady(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "reap-signal", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("dead"), []byte("ready")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm.ClaimBatch(ctx, id, 2)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(claimed) != 2 {
+		t.Fatalf("claimed %d, want 2", len(claimed))
+	}
+
+	now := time.Now()
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	for _, msg := range q.messages {
+		switch string(msg.Body) {
+		case "dead":
+			msg.MaxDeliveryCount = 1
+			msg.VisibilityDeadline = now.Add(-2 * time.Second)
+		case "ready":
+			msg.MaxDeliveryCount = 3
+			msg.VisibilityDeadline = now.Add(-1 * time.Second)
+		}
+	}
+	q.deadlines = q.deadlines[:0]
+	for _, dr := range q.inflight {
+		msg := q.messages[dr.MessageID]
+		dr.heapIndex = -1
+		dr.Deadline = msg.VisibilityDeadline
+		heap.Push(&q.deadlines, dr)
+	}
+	for {
+		select {
+		case <-q.readyCh:
+		default:
+			q.mu.Unlock()
+			goto drained
+		}
+	}
+
+drained:
+	transitions := qm.ReapExpired(ctx, now)
+	if len(transitions) != 2 {
+		t.Fatalf("transitions = %d, want 2", len(transitions))
+	}
+	if transitions[0].ToState != StateDead || transitions[1].ToState != StateReady {
+		t.Fatalf("transition order = %+v, want dead then ready", transitions)
+	}
+
+	select {
+	case <-q.readyCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected ready signal when a later reap transition returned a message to ready")
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2189,3 +2189,53 @@ func TestRuntimeReapWALFailPreservesInflight(t *testing.T) {
 		t.Fatalf("body = %q, want hello", claimed[0].Body)
 	}
 }
+
+// ============================================================================
+// T17: Ack releases byte quota for subsequent publishes
+// ============================================================================
+
+func TestRuntimeAckReleasesByteQuota(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "byte-quota", 3)
+	q, _ := qm.getQueue(id)
+	q.maxBytes = 5
+
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("12345")})
+	if err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+
+	// Second publish should exceed byte limit (5+5 > 5 is false, but 5+1 > 5 is true
+	// since bytesInMem is already 5). Actually: bytesInMem(5) + totalBytes(5) > maxBytes(5).
+	_, err = qm.PublishBatch(ctx, id, [][]byte{[]byte("67890")})
+	if err == nil {
+		t.Fatal("expected byte limit exceeded error")
+	}
+
+	// Claim and ack the first message.
+	claimed, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	results := qm.AckBatch(ctx, id, []AckEntry{
+		{ReceiptHandle: claimed[0].ReceiptHandle, DeliveryToken: claimed[0].DeliveryAttemptID},
+	})
+	if len(results) != 1 || results[0].Status != "ok" {
+		t.Fatalf("ack result = %+v", results)
+	}
+
+	// Byte quota should now be released; publish should succeed.
+	_, err = qm.PublishBatch(ctx, id, [][]byte{[]byte("abcde")})
+	if err != nil {
+		t.Fatalf("publish after ack should succeed: %v", err)
+	}
+
+	q.mu.Lock()
+	bytesInMem := q.bytesInMem
+	q.mu.Unlock()
+	if bytesInMem != 5 {
+		t.Fatalf("bytesInMem = %d, want 5", bytesInMem)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2239,3 +2239,49 @@ func TestRuntimeAckReleasesByteQuota(t *testing.T) {
 		t.Fatalf("bytesInMem = %d, want 5", bytesInMem)
 	}
 }
+
+// ============================================================================
+// T18: Duplicate receipt handles in ack batch are rejected
+// ============================================================================
+
+func TestRuntimeAckBatchRejectsDuplicateReceiptHandle(t *testing.T) {
+	qm, _ := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "dup-rh", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	// Same receipt handle and token twice in one batch.
+	results := qm.AckBatch(ctx, id, []AckEntry{
+		{ReceiptHandle: claimed[0].ReceiptHandle, DeliveryToken: claimed[0].DeliveryAttemptID},
+		{ReceiptHandle: claimed[0].ReceiptHandle, DeliveryToken: claimed[0].DeliveryAttemptID},
+	})
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Status != "ok" {
+		t.Fatalf("first result = %s, want ok", results[0].Status)
+	}
+	if results[1].Status != "error" {
+		t.Fatalf("second result = %s, want error (duplicate)", results[1].Status)
+	}
+	if !strings.Contains(results[1].Error, "duplicate") {
+		t.Fatalf("second result error = %q, want duplicate receipt handle", results[1].Error)
+	}
+
+	// Verify inFlightCount only decremented by 1.
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	inFlight := q.metrics.inFlightCount.Load()
+	q.mu.Unlock()
+	if inFlight != 0 {
+		t.Fatalf("inFlightCount = %d, want 0", inFlight)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -33,6 +33,7 @@ func setupTestDB(t *testing.T) {
 	queueReadyChans = map[string]chan struct{}{}
 	metricsStore = sync.Map{}
 	messageKeyCache = sync.Map{}
+	deliveryRecordSeq.Store(0)
 
 	t.Cleanup(func() {
 		_ = db.Close()
@@ -1451,6 +1452,12 @@ type fakeWAL struct {
 }
 
 func (f *fakeWAL) Append(ctx context.Context, entries []walEntry) (uint64, uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, 0, err
+	}
+	if len(entries) == 0 {
+		return 0, 0, nil
+	}
 	if f.beforeAppend != nil {
 		if err := f.beforeAppend(ctx, entries); err != nil {
 			return 0, 0, err
@@ -1461,13 +1468,9 @@ func (f *fakeWAL) Append(ctx context.Context, entries []walEntry) (uint64, uint6
 	if f.fail {
 		return 0, 0, errors.New("fake WAL failure")
 	}
-	first := f.nextLSN
-	if f.nextLSN == 0 {
-		f.nextLSN = 1
-		first = 1
-	}
+	first := f.nextLSN + 1
 	for i := range entries {
-		f.nextLSN++
+		f.nextLSN = first + uint64(i)
 		entries[i].LSN = f.nextLSN
 		f.entries = append(f.entries, entries[i])
 	}
@@ -1476,6 +1479,7 @@ func (f *fakeWAL) Append(ctx context.Context, entries []walEntry) (uint64, uint6
 
 func setupRuntimeTest(t *testing.T) (*queueManager, *fakeWAL) {
 	t.Helper()
+	deliveryRecordSeq.Store(0)
 	wal := &fakeWAL{}
 	qm := newQueueManager(wal)
 	return qm, wal

--- a/main_test.go
+++ b/main_test.go
@@ -2064,3 +2064,89 @@ func TestRuntimeMemoryLimitReject(t *testing.T) {
 		t.Fatalf("ready count = %d, want 1", readyCount)
 	}
 }
+
+// ============================================================================
+// T16: Reap WAL failure preserves inflight state for re-reaping
+// ============================================================================
+
+func TestRuntimeReapWALFailPreservesInflight(t *testing.T) {
+	qm, wal := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "reap-wal-fail", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("hello")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	_, err = qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	var rh string
+	for k := range q.inflight {
+		rh = k
+		break
+	}
+	if rh == "" {
+		t.Fatal("expected inflight delivery record")
+	}
+
+	for _, msg := range q.messages {
+		msg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
+	}
+	q.deadlines = q.deadlines[:0]
+	for _, dr := range q.inflight {
+		dr.heapIndex = -1
+		dr.Deadline = time.Now().Add(-1 * time.Second)
+		heap.Push(&q.deadlines, dr)
+	}
+	q.mu.Unlock()
+
+	wal.fail = true
+	transitions := qm.ReapExpired(ctx, time.Now())
+	if len(transitions) != 0 {
+		t.Fatalf("expected no transitions on WAL failure, got %d", len(transitions))
+	}
+
+	wal.fail = false
+
+	q.mu.Lock()
+	if len(q.inflight) != 1 {
+		t.Fatalf("inflight len = %d, want 1 after WAL failure", len(q.inflight))
+	}
+	if len(q.dead) != 0 {
+		t.Fatalf("dead len = %d, want 0 after WAL failure", len(q.dead))
+	}
+	if q.ready.Len() != 0 {
+		t.Fatalf("ready len = %d, want 0 after WAL failure", q.ready.Len())
+	}
+	if q.deadlines.Len() != 1 {
+		t.Fatalf("deadlines len = %d, want 1 after WAL failure", q.deadlines.Len())
+	}
+
+	for _, msg := range q.messages {
+		if msg.State != StateInFlight {
+			t.Fatalf("message state = %q, want in_flight", msg.State)
+		}
+	}
+	q.mu.Unlock()
+
+	transitions = qm.ReapExpired(ctx, time.Now())
+	if len(transitions) != 1 {
+		t.Fatalf("reap after WAL recovery: transitions = %d, want 1", len(transitions))
+	}
+	if transitions[0].ToState != StateReady {
+		t.Fatalf("reap toState = %q, want ready", transitions[0].ToState)
+	}
+
+	claimed, err := qm.ClaimBatch(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("claim after reap: %v", err)
+	}
+	if !bytes.Equal(claimed[0].Body, []byte("hello")) {
+		t.Fatalf("body = %q, want hello", claimed[0].Body)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2285,3 +2285,58 @@ func TestRuntimeAckBatchRejectsDuplicateReceiptHandle(t *testing.T) {
 		t.Fatalf("inFlightCount = %d, want 0", inFlight)
 	}
 }
+
+// ============================================================================
+// T19: Claim WAL failure leaves no stale inflight entries
+// ============================================================================
+
+func TestRuntimeClaimWALFailNoStaleInflight(t *testing.T) {
+	qm, wal := setupRuntimeTest(t)
+	ctx := context.Background()
+
+	id, _ := qm.CreateQueue(ctx, "claim-rollback", 3)
+	_, err := qm.PublishBatch(ctx, id, [][]byte{[]byte("a"), []byte("b")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	q, _ := qm.getQueue(id)
+	q.mu.Lock()
+	readyBefore := q.ready.Len()
+	q.mu.Unlock()
+	if readyBefore != 2 {
+		t.Fatalf("ready before = %d, want 2", readyBefore)
+	}
+
+	wal.fail = true
+	_, err = qm.ClaimBatch(ctx, id, 2)
+	if err == nil {
+		t.Fatal("expected WAL failure error")
+	}
+
+	q.mu.Lock()
+	inflightLen := len(q.inflight)
+	deadlinesLen := q.deadlines.Len()
+	readyAfter := q.ready.Len()
+	q.mu.Unlock()
+
+	if inflightLen != 0 {
+		t.Fatalf("inflight len after rollback = %d, want 0", inflightLen)
+	}
+	if deadlinesLen != 0 {
+		t.Fatalf("deadlines len after rollback = %d, want 0", deadlinesLen)
+	}
+	if readyAfter != 2 {
+		t.Fatalf("ready len after rollback = %d, want 2", readyAfter)
+	}
+
+	// After WAL failure, the messages should be claimable again.
+	wal.fail = false
+	claimed, err := qm.ClaimBatch(ctx, id, 2)
+	if err != nil {
+		t.Fatalf("claim after rollback: %v", err)
+	}
+	if len(claimed) != 2 {
+		t.Fatalf("claimed %d messages, want 2", len(claimed))
+	}
+}


### PR DESCRIPTION
Implements issue #27 - the in-memory queue state model that will replace Pebble as the runtime state machine. HTTP handlers are not switched in this PR; the new code lives behind internal APIs only.

Core changes:

- messageRecord / deliveryRecord - in-memory message and delivery tracking structs with readyElement (O(1) list removal) and heapIndex (O(log n) heap removal)
- visibilityHeap - min-heap by deadline for efficient reaper candidate lookup (no full DB scan)
- queueRuntime - per-queue isolated state: ready list, messages map, inflight map, dead map, deadlines heap, readyCh signal, per-queue mutex (no global claimMu/seqMu)
- queueManager - process-wide manager with RWMutex-protected queue map and walAppender interface
- 6 internal methods: CreateQueue, PublishBatch, ClaimBatch, AckBatch, Nack, ReapExpired - all with WAL-fail rollback
- walAppender interface - allows test fake WAL injection without Pebble dependency

Bug fixes found during implementation:

1. Reap WAL rollback deferred mutations - ReapExpired mutated state before WAL append; on failure rollback couldnt restore delivery records. Fixed: collect pending transitions first, only mutate after WAL succeeds.
2. Receipt handle stability across redeliveries - Nack/ReapExpired changed msg.Seq on redelivery, causing receipt handle to change. Stale ack got receipt-handle-not-found instead of delivery-token-mismatch. Fixed: Seq is now immutable after publish.
3. Byte quota leak on ack - AckBatch deleted messages but never subtracted len(msg.Body) from q.bytesInMem. Fixed: subtract body size on ack.
4. Stale inflight entries after claim WAL failure - Rollback cleared CurrentReceiptHandle before delete(q.inflight, ...), deleting empty-string key. Fixed: save receipt handle to local variable before clearing.
5. Duplicate receipt handles in AckBatch - Same receipt handle twice would validate twice, causing double metric updates. Fixed: track seen receipt handles, reject duplicates.

Tests: 20 runtime tests, all pass with -race. Pre-existing race in old Pebble code is unrelated.

go test ./... ✅
go test -race ./... ✅ (TestRuntime* only)
go build ./... ✅

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In-memory message queue runtime with FIFO ordering and delivery tracking
  * Dead-letter queue support for undeliverable messages
  * Write-ahead log persistence integration
  * Configurable memory limits for queue operations
  * Concurrent multi-queue operations support

* **Tests**
  * Comprehensive test coverage for queue runtime operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ayan-sh03/kueue/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->