### PR TITLE
Phase 2.3: Implement WAL replay into queueManager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Workload presets align with OpenMessaging canonical patterns:
 
 ## Architecture
 
-Everything lives in `main.go`. There is no package splitting.
+Code is in the root package (`package main`) split across focused files (`main.go`, `runtime.go`, `wal.go`, `recovery.go`). There is no sub-package splitting yet.
 
 ### HTTP routes
 
@@ -102,9 +102,42 @@ Per-queue in-memory counters in `queueMetrics`, stored in a `sync.Map` (`metrics
 
 `reapExpiredMessages` returns `[]reapTransition{QueueID, ToState}`. The reaper goroutine updates per-queue metrics per transition and only calls `signalQueueReady` when `ToState == StateReady` — dead-letter transitions must not wake long-polling consumers.
 
+### Runtime model
+
+`runtime.go` holds the in-memory queue manager (`queueManager`) and is being introduced in Phase 2. Each queue has:
+- A ready list (`readyList`) of messages ordered by monotonic sequence number for FIFO delivery.
+- An in-flight map (`inflight`) keyed by receipt handle, plus a deadline heap (`deadlineHeap`) ordered by `VisibilityDeadline`.
+- A dead-letter set (`dead`) of messages that exceeded `MaxDeliveryCount`.
+- Per-queue `nextSeq` and `bytesInMem` counters.
+
+State transitions follow: `ready -> in_flight -> ready|dead`. The runtime is the source of truth during Phase 2; Pebble still contains the legacy data layout until Phase 2.8 migration.
+
+### WAL
+
+`wal.go` implements a write-ahead log on top of Pebble. Every mutating runtime operation is recorded as a `WALEntry` before being applied. Entries are encoded as JSON per `WALEntry` and appended to the Pebble log. Supported operations: `create`, `publish`, `claim`, `ack`, `nack`, `reap`.
+
+The WAL stores:
+- `snapshot_lsn`: last snapshot LSN (currently `0`; reserved for Phase 2.7).
+- `next_lsn`: next write LSN.
+- `entries`: per-LSN entries.
+
+Snapshots truncate the log; replay starts from the latest snapshot LSN.
+
+### Recovery
+
+`recovery.go` rebuilds the runtime model at startup. `main()` calls `initQueueManagerFromEnv`, which:
+1. Opens/creates the `walStore` from Pebble.
+2. Creates an empty `queueManager`.
+3. Replays every WAL entry through `ApplyWALEntry`.
+4. Runs one `ReapExpired` pass to drain any in-flight messages that expired while the server was down.
+
+`ApplyWALEntry` validates consistency strictly: duplicate queue creates, missing messages, wrong states, or stale delivery tokens fail loudly and stop startup. During replay, ready channels are not signaled because there are no consumers yet.
+
 ## Testing
 
-Tests in `main_test.go` use `httptest.NewRecorder` + direct handler calls against a temp Pebble DB. No HTTP server startup. Pattern: `setupTestDB(t)` opens Pebble in `t.TempDir()` and resets global state including `metricsStore`, `messageKeyCache`, `receiveChannel`, and `queueReadyChans`. Tests do NOT test the reaper goroutine directly — they call `reapExpiredMessages` synchronously.
+Tests in `main_test.go` use `httptest.NewRecorder` + direct handler calls against a temp Pebble DB. No HTTP server startup. Pattern: `setupTestDB(t)` opens Pebble in `t.TempDir()` and resets global state including `metricsStore`, `messageKeyCache`, `receiveChannel`, `queueReadyChans`, `QueueManager`, and `WAL`. Tests do NOT test the reaper goroutine directly — they call `reapExpiredMessages` synchronously.
+
+Runtime/WAL/recovery tests typically build state through the runtime API, close the Pebble DB, reopen it, and call `recoverQueueManager` / `ApplyWALEntry` to verify that the in-memory model is rebuilt correctly.
 
 When adding new global state (like `metricsStore`), add cleanup in `setupTestDB`.
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -29,6 +30,15 @@ func main() {
 	Db = db
 	defer Db.Close()
 	fmt.Println("DB initialised successfully")
+
+	qm, wal, err := initQueueManagerFromEnv(context.Background(), Db)
+	if err != nil {
+		log.Fatalf("recovery failed: %v", err)
+	}
+	QueueManager = qm
+	WAL = wal
+	fmt.Println("WAL replay complete")
+
 	http.HandleFunc("/", queueHandler)
 	http.HandleFunc("/create", create)
 	http.HandleFunc("/get", getQueue)

--- a/main_test.go
+++ b/main_test.go
@@ -2988,3 +2988,105 @@ func TestReplayInconsistentRecordFailsStartup(t *testing.T) {
 	}
 }
 
+func TestReplayAckMessageIDMismatchFailsStartup(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, wal1, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "ack-mismatch", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	published, err := qm1.PublishBatch(context.Background(), id, [][]byte{[]byte("first"), []byte("second")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm1.ClaimBatch(context.Background(), id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	// Append a bad ack that uses the correct receipt handle and token but a
+	// MessageID that belongs to a different (still ready) message.
+	wrongMessageID := published[1]
+	if _, _, err := wal1.Append(context.Background(), []walEntry{
+		{Op: opAckBatch, Payload: walAckBatchPayload{
+			QueueID: id,
+			Acks: []walAckedMessage{{
+				MessageID:     wrongMessageID,
+				ReceiptHandle: claimed[0].ReceiptHandle,
+				DeliveryToken: claimed[0].DeliveryAttemptID,
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("append bad ack: %v", err)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	db2, err := pebble.Open(dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("reopen pebble: %v", err)
+	}
+	defer db2.Close()
+	wal2, err := newWalStore(db2, walSyncNone)
+	if err != nil {
+		t.Fatalf("new wal store on reopen: %v", err)
+	}
+	qm2 := newQueueManager(wal2)
+	if err := wal2.Replay(context.Background(), wal2.latestSnapshotLSN, qm2.ApplyWALEntry); err == nil {
+		t.Fatal("expected replay to fail on ack MessageID mismatch")
+	}
+}
+
+func TestReplayNackMessageIDMismatchFailsStartup(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, wal1, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "nack-mismatch", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	published, err := qm1.PublishBatch(context.Background(), id, [][]byte{[]byte("first"), []byte("second")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm1.ClaimBatch(context.Background(), id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	// Append a bad nack that uses the correct receipt handle and token but a
+	// MessageID that belongs to a different (still ready) message.
+	wrongMessageID := published[1]
+	if _, _, err := wal1.Append(context.Background(), []walEntry{
+		{Op: opNack, Payload: walNackPayload{
+			QueueID:        id,
+			MessageID:      wrongMessageID,
+			ReceiptHandle:  claimed[0].ReceiptHandle,
+			DeliveryToken:  claimed[0].DeliveryAttemptID,
+			TargetState:    StateReady,
+			HasNewReadySeq: false,
+		}},
+	}); err != nil {
+		t.Fatalf("append bad nack: %v", err)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	db2, err := pebble.Open(dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("reopen pebble: %v", err)
+	}
+	defer db2.Close()
+	wal2, err := newWalStore(db2, walSyncNone)
+	if err != nil {
+		t.Fatalf("new wal store on reopen: %v", err)
+	}
+	qm2 := newQueueManager(wal2)
+	if err := wal2.Replay(context.Background(), wal2.latestSnapshotLSN, qm2.ApplyWALEntry); err == nil {
+		t.Fatal("expected replay to fail on nack MessageID mismatch")
+	}
+}
+

--- a/main_test.go
+++ b/main_test.go
@@ -2789,6 +2789,9 @@ func TestReplayNackReturnsToTail(t *testing.T) {
 	if !slicesEqual(bodies, want) {
 		t.Fatalf("ready order = %v, want %v", bodies, want)
 	}
+	if got := q.metrics.totalNacked.Load(); got != 1 {
+		t.Fatalf("totalNacked = %d, want 1", got)
+	}
 }
 
 func TestReplayExpiredInflightBecomesReady(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -2537,3 +2537,454 @@ func slicesEqual(a, b []string) bool {
 	}
 	return true
 }
+
+// ============================================================================
+// Phase 2.3: WAL replay into queueManager
+// ============================================================================
+
+func openRuntimeWAL(t *testing.T, dir string) (*queueManager, *walStore, *pebble.DB) {
+	t.Helper()
+	deliveryRecordSeq.Store(0)
+	metricsStore = sync.Map{}
+
+	db, err := pebble.Open(dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+
+	wal, err := newWalStore(db, walSyncNone)
+	if err != nil {
+		t.Fatalf("new wal store: %v", err)
+	}
+	qm := newQueueManager(wal)
+	return qm, wal, db
+}
+
+func recoverRuntimeWAL(t *testing.T, dir string) (*queueManager, *walStore, *pebble.DB) {
+	t.Helper()
+	deliveryRecordSeq.Store(0)
+	metricsStore = sync.Map{}
+
+	db, err := pebble.Open(dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("reopen pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	wal, err := newWalStore(db, walSyncNone)
+	if err != nil {
+		t.Fatalf("new wal store on reopen: %v", err)
+	}
+	qm := newQueueManager(wal)
+	if err := wal.Replay(context.Background(), wal.latestSnapshotLSN, qm.ApplyWALEntry); err != nil {
+		t.Fatalf("replay wal: %v", err)
+	}
+	return qm, wal, db
+}
+
+func TestReplayCreateQueueSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, _, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "replay-test", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	qm2, _, _ := recoverRuntimeWAL(t, dir)
+	q, err := qm2.getQueue(id)
+	if err != nil {
+		t.Fatalf("get queue after replay: %v", err)
+	}
+	q.mu.Lock()
+	if q.config.Name != "replay-test" || q.config.MaxRetries != 3 {
+		t.Fatalf("config = %+v, want name=replay-test retries=3", q.config)
+	}
+	q.mu.Unlock()
+}
+
+func TestReplayReadyMessagesFIFO(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, _, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "fifo", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	ids, err := qm1.PublishBatch(context.Background(), id, [][]byte{[]byte("a"), []byte("b"), []byte("c")})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	qm2, _, _ := recoverRuntimeWAL(t, dir)
+	q, err := qm2.getQueue(id)
+	if err != nil {
+		t.Fatalf("get queue after replay: %v", err)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.ready.Len() != 3 {
+		t.Fatalf("ready len = %d, want 3", q.ready.Len())
+	}
+	var got []string
+	for e := q.ready.Front(); e != nil; e = e.Next() {
+		got = append(got, string(e.Value.(*messageRecord).Body))
+	}
+	want := []string{"a", "b", "c"}
+	if !slicesEqual(got, want) {
+		t.Fatalf("ready order = %v, want %v", got, want)
+	}
+	for _, id := range ids {
+		if _, ok := q.messages[id]; !ok {
+			t.Fatalf("message %s missing after replay", id)
+		}
+	}
+	if q.nextSeq < 3 {
+		t.Fatalf("nextSeq = %d, want >= 3", q.nextSeq)
+	}
+}
+
+func TestReplayInFlightPreservesHandleTokenDeadline(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, _, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "inflight", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	if _, err := qm1.PublishBatch(context.Background(), id, [][]byte{[]byte("x")}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm1.ClaimBatch(context.Background(), id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	orig := claimed[0]
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	qm2, _, _ := recoverRuntimeWAL(t, dir)
+	q, err := qm2.getQueue(id)
+	if err != nil {
+		t.Fatalf("get queue after replay: %v", err)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.ready.Len() != 0 {
+		t.Fatalf("ready len = %d, want 0", q.ready.Len())
+	}
+	if len(q.inflight) != 1 {
+		t.Fatalf("inflight len = %d, want 1", len(q.inflight))
+	}
+	dr := q.inflight[orig.ReceiptHandle]
+	if dr == nil {
+		t.Fatal("delivery record missing after replay")
+	}
+	if dr.DeliveryToken != orig.DeliveryAttemptID {
+		t.Fatalf("token = %q, want %q", dr.DeliveryToken, orig.DeliveryAttemptID)
+	}
+	if !dr.Deadline.Equal(orig.VisibilityDeadline) {
+		t.Fatalf("deadline = %v, want %v", dr.Deadline, orig.VisibilityDeadline)
+	}
+	if q.deadlines.Len() != 1 {
+		t.Fatalf("deadlines heap len = %d, want 1", q.deadlines.Len())
+	}
+	msg := q.messages[orig.ID]
+	if msg == nil || msg.State != StateInFlight {
+		t.Fatalf("message state = %v, want in_flight", msg.State)
+	}
+}
+
+func TestReplayAckedMessagesDoNotReappear(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, _, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "ack", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	if _, err := qm1.PublishBatch(context.Background(), id, [][]byte{[]byte("x")}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm1.ClaimBatch(context.Background(), id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	results := qm1.AckBatch(context.Background(), id, []AckEntry{
+		{ReceiptHandle: claimed[0].ReceiptHandle, DeliveryToken: claimed[0].DeliveryAttemptID},
+	})
+	if results[0].Status != "ok" {
+		t.Fatalf("ack failed: %s", results[0].Error)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	qm2, _, _ := recoverRuntimeWAL(t, dir)
+	q, err := qm2.getQueue(id)
+	if err != nil {
+		t.Fatalf("get queue after replay: %v", err)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.messages) != 0 {
+		t.Fatalf("messages len = %d, want 0", len(q.messages))
+	}
+	if len(q.inflight) != 0 {
+		t.Fatalf("inflight len = %d, want 0", len(q.inflight))
+	}
+	if q.ready.Len() != 0 {
+		t.Fatalf("ready len = %d, want 0", q.ready.Len())
+	}
+}
+
+func TestReplayNackReturnsToTail(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, _, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "nack", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	if _, err := qm1.PublishBatch(context.Background(), id, [][]byte{[]byte("first"), []byte("second")}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed, err := qm1.ClaimBatch(context.Background(), id, 1)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if _, err := qm1.Nack(context.Background(), id, claimed[0].ReceiptHandle, claimed[0].DeliveryAttemptID); err != nil {
+		t.Fatalf("nack: %v", err)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	qm2, _, _ := recoverRuntimeWAL(t, dir)
+	q, err := qm2.getQueue(id)
+	if err != nil {
+		t.Fatalf("get queue after replay: %v", err)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.ready.Len() != 2 {
+		t.Fatalf("ready len = %d, want 2", q.ready.Len())
+	}
+	var bodies []string
+	for e := q.ready.Front(); e != nil; e = e.Next() {
+		bodies = append(bodies, string(e.Value.(*messageRecord).Body))
+	}
+	want := []string{"second", "first"}
+	if !slicesEqual(bodies, want) {
+		t.Fatalf("ready order = %v, want %v", bodies, want)
+	}
+}
+
+func TestReplayExpiredInflightBecomesReady(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, _, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "expired", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	if _, err := qm1.PublishBatch(context.Background(), id, [][]byte{[]byte("x")}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if _, err := qm1.ClaimBatch(context.Background(), id, 1); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	qm2, _, _ := recoverRuntimeWAL(t, dir)
+	q, err := qm2.getQueue(id)
+	if err != nil {
+		t.Fatalf("get queue after replay: %v", err)
+	}
+
+	q.mu.Lock()
+	if len(q.inflight) != 1 {
+		t.Fatalf("inflight len = %d, want 1", len(q.inflight))
+	}
+	for _, dr := range q.inflight {
+		// Force an expired deadline by moving it into the past.
+		dr.Deadline = time.Now().Add(-time.Second)
+	}
+	for _, msg := range q.messages {
+		msg.VisibilityDeadline = time.Now().Add(-time.Second)
+	}
+	q.deadlines = q.deadlines[:0]
+	for _, dr := range q.inflight {
+		dr.heapIndex = -1
+		heap.Push(&q.deadlines, dr)
+	}
+	q.mu.Unlock()
+
+	transitions := qm2.ReapExpired(context.Background(), time.Now())
+	if len(transitions) != 1 || transitions[0].ToState != StateReady {
+		t.Fatalf("transitions = %+v, want one ready", transitions)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.ready.Len() != 1 {
+		t.Fatalf("ready len after startup reap = %d, want 1", q.ready.Len())
+	}
+	if len(q.inflight) != 0 {
+		t.Fatalf("inflight len after startup reap = %d, want 0", len(q.inflight))
+	}
+}
+
+func TestReplayExpiredInflightMaxDeliveryBecomesDead(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, _, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "dead-letter", 1)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	if _, err := qm1.PublishBatch(context.Background(), id, [][]byte{[]byte("x")}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if _, err := qm1.ClaimBatch(context.Background(), id, 1); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	qm2, _, _ := recoverRuntimeWAL(t, dir)
+	q, err := qm2.getQueue(id)
+	if err != nil {
+		t.Fatalf("get queue after replay: %v", err)
+	}
+
+	q.mu.Lock()
+	for _, msg := range q.messages {
+		msg.VisibilityDeadline = time.Now().Add(-time.Second)
+	}
+	q.deadlines = q.deadlines[:0]
+	for _, dr := range q.inflight {
+		dr.Deadline = time.Now().Add(-time.Second)
+		dr.heapIndex = -1
+		heap.Push(&q.deadlines, dr)
+	}
+	q.mu.Unlock()
+
+	transitions := qm2.ReapExpired(context.Background(), time.Now())
+	if len(transitions) != 1 || transitions[0].ToState != StateDead {
+		t.Fatalf("transitions = %+v, want one dead", transitions)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.dead) != 1 {
+		t.Fatalf("dead len = %d, want 1", len(q.dead))
+	}
+	if len(q.inflight) != 0 {
+		t.Fatalf("inflight len = %d, want 0", len(q.inflight))
+	}
+}
+
+func TestReplayStaleAckTokenRejected(t *testing.T) {
+	dir := t.TempDir()
+
+	qm1, _, db1 := openRuntimeWAL(t, dir)
+	id, err := qm1.CreateQueue(context.Background(), "stale", 3)
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	if _, err := qm1.PublishBatch(context.Background(), id, [][]byte{[]byte("x")}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	claimed1, err := qm1.ClaimBatch(context.Background(), id, 1)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	oldToken := claimed1[0].DeliveryAttemptID
+
+	// Let the message expire and be reaped, then claimed again with a new token.
+	q, _ := qm1.getQueue(id)
+	q.mu.Lock()
+	for _, msg := range q.messages {
+		msg.VisibilityDeadline = time.Now().Add(-time.Second)
+	}
+	q.deadlines = q.deadlines[:0]
+	for _, dr := range q.inflight {
+		dr.Deadline = time.Now().Add(-time.Second)
+		dr.heapIndex = -1
+		heap.Push(&q.deadlines, dr)
+	}
+	q.mu.Unlock()
+	qm1.ReapExpired(context.Background(), time.Now())
+
+	claimed2, err := qm1.ClaimBatch(context.Background(), id, 1)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	qm2, _, _ := recoverRuntimeWAL(t, dir)
+	// Try to ack with the old token.
+	results := qm2.AckBatch(context.Background(), id, []AckEntry{
+		{ReceiptHandle: claimed2[0].ReceiptHandle, DeliveryToken: oldToken},
+	})
+	if results[0].Status == "ok" {
+		t.Fatal("expected stale token ack to fail")
+	}
+}
+
+func TestReplayInconsistentRecordFailsStartup(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := pebble.Open(dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	wal, err := newWalStore(db, walSyncNone)
+	if err != nil {
+		t.Fatalf("new wal store: %v", err)
+	}
+
+	// Append a create queue followed by an ack for a non-existent message.
+	if _, _, err := wal.Append(context.Background(), []walEntry{
+		{Op: opCreateQueue, Payload: walCreateQueuePayload{QueueID: "q", Name: "q", MaxRetries: 3}},
+		{Op: opAckBatch, Payload: walAckBatchPayload{
+			QueueID: "q",
+			Acks:    []walAckedMessage{{MessageID: "m1", ReceiptHandle: "rh", DeliveryToken: "tok"}},
+		}},
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	_ = db.Close()
+
+	db2, err := pebble.Open(dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("reopen pebble: %v", err)
+	}
+	defer db2.Close()
+	wal2, err := newWalStore(db2, walSyncNone)
+	if err != nil {
+		t.Fatalf("new wal store on reopen: %v", err)
+	}
+	qm := newQueueManager(wal2)
+	if err := wal2.Replay(context.Background(), wal2.latestSnapshotLSN, qm.ApplyWALEntry); err == nil {
+		t.Fatal("expected replay to fail on inconsistent ack record")
+	}
+}
+

--- a/recovery.go
+++ b/recovery.go
@@ -274,7 +274,11 @@ func (qm *queueManager) applyNack(p walNackPayload) error {
 	}
 	delete(q.inflight, p.ReceiptHandle)
 
-	return q.applyNackOrReapToMessage(msg, p.TargetState, p.HasNewReadySeq, p.NewReadySeq)
+	if err := q.applyNackOrReapToMessage(msg, p.TargetState, p.HasNewReadySeq, p.NewReadySeq); err != nil {
+		return err
+	}
+	q.metrics.totalNacked.Add(1)
+	return nil
 }
 
 func (qm *queueManager) applyReapBatch(p walReapBatchPayload) error {

--- a/recovery.go
+++ b/recovery.go
@@ -224,6 +224,9 @@ func (qm *queueManager) applyAckBatch(p walAckBatchPayload) error {
 		if dr.DeliveryToken != wa.DeliveryToken {
 			return fmt.Errorf("ack batch: delivery token mismatch for receipt handle %q", wa.ReceiptHandle)
 		}
+		if dr.MessageID != wa.MessageID {
+			return fmt.Errorf("ack batch: message ID mismatch for receipt handle %q (inflight=%q, wal=%q)", wa.ReceiptHandle, dr.MessageID, wa.MessageID)
+		}
 
 		if dr.heapIndex >= 0 && dr.heapIndex < len(q.deadlines) {
 			heap.Remove(&q.deadlines, dr.heapIndex)
@@ -256,6 +259,9 @@ func (qm *queueManager) applyNack(p walNackPayload) error {
 	}
 	if dr.DeliveryToken != p.DeliveryToken {
 		return fmt.Errorf("nack: delivery token mismatch for receipt handle %q", p.ReceiptHandle)
+	}
+	if dr.MessageID != p.MessageID {
+		return fmt.Errorf("nack: message ID mismatch for receipt handle %q (inflight=%q, wal=%q)", p.ReceiptHandle, dr.MessageID, p.MessageID)
 	}
 
 	msg, ok := q.messages[p.MessageID]

--- a/recovery.go
+++ b/recovery.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"container/heap"
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// Phase 2.3: WAL replay into queueManager.
+
+var (
+	// QueueManager is the process-wide in-memory queue runtime.
+	QueueManager *queueManager
+	// WAL is the durable append-only log backing QueueManager.
+	WAL *walStore
+)
+
+// recoverQueueManager opens the WAL store, creates an empty queueManager, and
+// replays all WAL entries after the latest snapshot LSN. After replay it runs
+// one reaper pass for in-flight deliveries that already expired while the
+// process was down. Any replay error is returned and startup must not proceed.
+func recoverQueueManager(ctx context.Context, db *pebble.DB, syncMode walSyncMode) (*queueManager, *walStore, error) {
+	wal, err := newWalStore(db, syncMode)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open wal store: %w", err)
+	}
+
+	qm := newQueueManager(wal)
+
+	if err := wal.Replay(ctx, wal.latestSnapshotLSN, qm.ApplyWALEntry); err != nil {
+		return nil, nil, fmt.Errorf("replay wal: %w", err)
+	}
+
+	// Drain deliveries whose visibility timeout already passed while we were
+	// down. This appends reap entries to the WAL so the transitions are durable.
+	qm.ReapExpired(ctx, time.Now())
+
+	return qm, wal, nil
+}
+
+// initQueueManagerFromEnv is a convenience wrapper that reads KUEUE_WAL_SYNC
+// from the environment and recovers the queue manager from the supplied DB.
+func initQueueManagerFromEnv(ctx context.Context, db *pebble.DB) (*queueManager, *walStore, error) {
+	syncMode, err := walSyncModeFromEnv()
+	if err != nil {
+		return nil, nil, err
+	}
+	return recoverQueueManager(ctx, db, syncMode)
+}
+
+// ApplyWALEntry applies a single WAL entry to the in-memory queue manager.
+// It is used during recovery and must be deterministic: the same WAL order
+// always produces the same final state. Inconsistent records fail loudly.
+func (qm *queueManager) ApplyWALEntry(entry walEntry) error {
+	switch entry.Op {
+	case opCreateQueue:
+		p, ok := entry.Payload.(walCreateQueuePayload)
+		if !ok {
+			return fmt.Errorf("LSN %d: invalid create queue payload type %T", entry.LSN, entry.Payload)
+		}
+		return qm.applyCreateQueue(p)
+	case opPublishBatch:
+		p, ok := entry.Payload.(walPublishBatchPayload)
+		if !ok {
+			return fmt.Errorf("LSN %d: invalid publish batch payload type %T", entry.LSN, entry.Payload)
+		}
+		return qm.applyPublishBatch(p)
+	case opClaimBatch:
+		p, ok := entry.Payload.(walClaimBatchPayload)
+		if !ok {
+			return fmt.Errorf("LSN %d: invalid claim batch payload type %T", entry.LSN, entry.Payload)
+		}
+		return qm.applyClaimBatch(p)
+	case opAckBatch:
+		p, ok := entry.Payload.(walAckBatchPayload)
+		if !ok {
+			return fmt.Errorf("LSN %d: invalid ack batch payload type %T", entry.LSN, entry.Payload)
+		}
+		return qm.applyAckBatch(p)
+	case opNack:
+		p, ok := entry.Payload.(walNackPayload)
+		if !ok {
+			return fmt.Errorf("LSN %d: invalid nack payload type %T", entry.LSN, entry.Payload)
+		}
+		return qm.applyNack(p)
+	case opReapBatch:
+		p, ok := entry.Payload.(walReapBatchPayload)
+		if !ok {
+			return fmt.Errorf("LSN %d: invalid reap batch payload type %T", entry.LSN, entry.Payload)
+		}
+		return qm.applyReapBatch(p)
+	default:
+		return fmt.Errorf("LSN %d: unknown WAL op %d", entry.LSN, entry.Op)
+	}
+}
+
+func (qm *queueManager) applyCreateQueue(p walCreateQueuePayload) error {
+	if p.QueueID == "" {
+		return errors.New("create queue: empty queue id")
+	}
+
+	qm.mu.Lock()
+	defer qm.mu.Unlock()
+
+	if _, exists := qm.queues[p.QueueID]; exists {
+		return fmt.Errorf("create queue: queue %q already exists", p.QueueID)
+	}
+
+	config := QueueConfig{Name: p.Name, MaxRetries: p.MaxRetries}
+	qm.queues[p.QueueID] = newQueueRuntime(p.QueueID, config, getOrCreateMetrics(p.QueueID))
+	return nil
+}
+
+func (qm *queueManager) applyPublishBatch(p walPublishBatchPayload) error {
+	q, err := qm.getQueue(p.QueueID)
+	if err != nil {
+		return fmt.Errorf("publish batch: %w", err)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	var totalBytes int64
+	for _, wm := range p.Messages {
+		if wm.MessageID == "" {
+			return errors.New("publish batch: empty message id")
+		}
+		if _, exists := q.messages[wm.MessageID]; exists {
+			return fmt.Errorf("publish batch: message %q already exists", wm.MessageID)
+		}
+
+		msg := &messageRecord{
+			ID:               wm.MessageID,
+			QueueID:          p.QueueID,
+			Seq:              wm.Seq,
+			Body:             wm.Body,
+			State:            StateReady,
+			EnqueuedAt:       wm.EnqueuedAt,
+			DeliveryCount:    0,
+			MaxDeliveryCount: wm.MaxDeliveryCount,
+		}
+		msg.readyElement = q.ready.PushBack(msg)
+		q.messages[msg.ID] = msg
+
+		if msg.Seq >= q.nextSeq {
+			q.nextSeq = msg.Seq + 1
+		}
+		totalBytes += int64(len(msg.Body))
+	}
+
+	q.bytesInMem += totalBytes
+	q.metrics.totalPublished.Add(int64(len(p.Messages)))
+	q.metrics.readyCount.Add(int64(len(p.Messages)))
+	return nil
+}
+
+func (qm *queueManager) applyClaimBatch(p walClaimBatchPayload) error {
+	q, err := qm.getQueue(p.QueueID)
+	if err != nil {
+		return fmt.Errorf("claim batch: %w", err)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for _, wc := range p.Claims {
+		msg, ok := q.messages[wc.MessageID]
+		if !ok {
+			return fmt.Errorf("claim batch: message %q not found", wc.MessageID)
+		}
+		if msg.State != StateReady {
+			return fmt.Errorf("claim batch: message %q is %q, want ready", wc.MessageID, msg.State)
+		}
+
+		// Remove from ready list.
+		if msg.readyElement == nil {
+			return fmt.Errorf("claim batch: message %q has no ready element", wc.MessageID)
+		}
+		q.ready.Remove(msg.readyElement)
+		msg.readyElement = nil
+
+		msg.State = StateInFlight
+		msg.DeliveryCount = wc.DeliveryCount
+		msg.CurrentReceiptHandle = wc.ReceiptHandle
+		msg.CurrentDeliveryToken = wc.DeliveryToken
+		msg.VisibilityDeadline = wc.VisibilityDeadline
+
+		dr := &deliveryRecord{
+			MessageID:     msg.ID,
+			ReceiptHandle: msg.CurrentReceiptHandle,
+			DeliveryToken: msg.CurrentDeliveryToken,
+			Deadline:      msg.VisibilityDeadline,
+			DeliveryCount: msg.DeliveryCount,
+			seq:           deliveryRecordSeq.Add(1),
+		}
+		q.inflight[dr.ReceiptHandle] = dr
+		heap.Push(&q.deadlines, dr)
+	}
+
+	q.metrics.readyCount.Add(-int64(len(p.Claims)))
+	q.metrics.inFlightCount.Add(int64(len(p.Claims)))
+	q.metrics.totalReceived.Add(int64(len(p.Claims)))
+	return nil
+}
+
+func (qm *queueManager) applyAckBatch(p walAckBatchPayload) error {
+	q, err := qm.getQueue(p.QueueID)
+	if err != nil {
+		return fmt.Errorf("ack batch: %w", err)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for _, wa := range p.Acks {
+		dr, ok := q.inflight[wa.ReceiptHandle]
+		if !ok {
+			return fmt.Errorf("ack batch: receipt handle %q not found", wa.ReceiptHandle)
+		}
+		if dr.DeliveryToken != wa.DeliveryToken {
+			return fmt.Errorf("ack batch: delivery token mismatch for receipt handle %q", wa.ReceiptHandle)
+		}
+
+		if dr.heapIndex >= 0 && dr.heapIndex < len(q.deadlines) {
+			heap.Remove(&q.deadlines, dr.heapIndex)
+		}
+		delete(q.inflight, wa.ReceiptHandle)
+
+		if msg, ok := q.messages[wa.MessageID]; ok {
+			q.bytesInMem -= int64(len(msg.Body))
+			delete(q.messages, wa.MessageID)
+		}
+	}
+
+	q.metrics.inFlightCount.Add(-int64(len(p.Acks)))
+	q.metrics.totalAcked.Add(int64(len(p.Acks)))
+	return nil
+}
+
+func (qm *queueManager) applyNack(p walNackPayload) error {
+	q, err := qm.getQueue(p.QueueID)
+	if err != nil {
+		return fmt.Errorf("nack: %w", err)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	dr, ok := q.inflight[p.ReceiptHandle]
+	if !ok {
+		return fmt.Errorf("nack: receipt handle %q not found", p.ReceiptHandle)
+	}
+	if dr.DeliveryToken != p.DeliveryToken {
+		return fmt.Errorf("nack: delivery token mismatch for receipt handle %q", p.ReceiptHandle)
+	}
+
+	msg, ok := q.messages[p.MessageID]
+	if !ok {
+		return fmt.Errorf("nack: message %q not found", p.MessageID)
+	}
+
+	if dr.heapIndex >= 0 && dr.heapIndex < len(q.deadlines) {
+		heap.Remove(&q.deadlines, dr.heapIndex)
+	}
+	delete(q.inflight, p.ReceiptHandle)
+
+	return q.applyNackOrReapToMessage(msg, p.TargetState, p.HasNewReadySeq, p.NewReadySeq)
+}
+
+func (qm *queueManager) applyReapBatch(p walReapBatchPayload) error {
+	q, err := qm.getQueue(p.QueueID)
+	if err != nil {
+		return fmt.Errorf("reap batch: %w", err)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for _, wr := range p.Reaps {
+		msg, ok := q.messages[wr.MessageID]
+		if !ok {
+			return fmt.Errorf("reap batch: message %q not found", wr.MessageID)
+		}
+		if msg.State != StateInFlight {
+			return fmt.Errorf("reap batch: message %q is %q, want in_flight", wr.MessageID, msg.State)
+		}
+		if msg.CurrentDeliveryToken != wr.PreviousDeliveryToken {
+			return fmt.Errorf("reap batch: delivery token mismatch for message %q", wr.MessageID)
+		}
+
+		// Locate the delivery record via the message's current receipt handle.
+		dr, ok := q.inflight[msg.CurrentReceiptHandle]
+		if !ok {
+			return fmt.Errorf("reap batch: delivery record for message %q not found", wr.MessageID)
+		}
+		if dr.DeliveryToken != wr.PreviousDeliveryToken {
+			return fmt.Errorf("reap batch: delivery record token mismatch for message %q", wr.MessageID)
+		}
+
+		if dr.heapIndex >= 0 && dr.heapIndex < len(q.deadlines) {
+			heap.Remove(&q.deadlines, dr.heapIndex)
+		}
+		delete(q.inflight, dr.ReceiptHandle)
+
+		if err := q.applyNackOrReapToMessage(msg, wr.TargetState, wr.HasNewReadySeq, wr.NewReadySeq); err != nil {
+			return fmt.Errorf("reap batch: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// applyNackOrReapToMessage transitions a message from in_flight to ready or
+// dead. It assumes the caller holds q.mu and has already removed the delivery
+// record from q.inflight and the deadline heap. It updates metrics but does
+// not signal readyCh (recovery has no waiting consumers).
+func (q *queueRuntime) applyNackOrReapToMessage(msg *messageRecord, targetState MessageState, hasNewReadySeq bool, newReadySeq uint64) error {
+	switch targetState {
+	case StateDead:
+		msg.State = StateDead
+		q.dead[msg.ID] = msg
+		q.metrics.deadCount.Add(1)
+	case StateReady:
+		msg.State = StateReady
+		msg.CurrentReceiptHandle = ""
+		msg.CurrentDeliveryToken = ""
+		msg.VisibilityDeadline = time.Time{}
+		if hasNewReadySeq {
+			msg.Seq = newReadySeq
+			if newReadySeq >= q.nextSeq {
+				q.nextSeq = newReadySeq + 1
+			}
+		}
+		msg.readyElement = q.ready.PushBack(msg)
+		q.metrics.readyCount.Add(1)
+	default:
+		return fmt.Errorf("invalid target state %q", targetState)
+	}
+
+	q.metrics.inFlightCount.Add(-1)
+	return nil
+}


### PR DESCRIPTION
Closes #28

## Summary
Adds the startup recovery backbone: open the WAL, create an empty queueManager, replay every WAL entry into memory, then run one startup reaper pass for already-expired in-flight deliveries.

## Changes
- ecovery.go (new):
  - Globals QueueManager / WAL.
  - ecoverQueueManager / initQueueManagerFromEnv.
  - ApplyWALEntry and per-op apply helpers for create, publish, claim, ck, 
ack, eap.
  - Rebuilds ready lists, inflight map, deadline heap, dead map, per-queue 
extSeq, bytes-in-memory, and metrics.
  - Fails loudly on inconsistent WAL records.
- main.go: initializes walStore + queueManager and replays before starting HTTP server.
- main_test.go: restart-style recovery tests.

## Validation
- go test ./... ✅
- go test -race ./... ✅
- go vet ./... ✅
- go build ./... ✅

## Notes
- HTTP handlers still use the old Pebble hot path; they are not switched yet.
- 	otalNacked is not rebuilt because the runtime Nack/ReapExpired methods do not currently increment it; that can be aligned separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WAL-based recovery so queue and message state persist and are automatically replayed on startup.
* **Bug Fixes**
  * Improved replay consistency: message ordering, delivery counts, ack/nack semantics, and expired in-flight handling are preserved across restarts.
* **Tests**
  * Added end-to-end tests covering many WAL replay scenarios (ordering, ack/token behavior, dead-lettering).
* **Documentation**
  * Updated architecture and recovery docs to describe WAL, replay, and testing patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->