### PR TITLE
Phase 2.4: Switch create, publish, receive, ack, nack handlers + reaper to queueRuntime + WAL

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -28,3 +28,11 @@ func (e *ErrInvalidReceiptHandle) Error() string {
 var ErrNoReadyMessages = errors.New("no ready messages")
 
 var ErrMessageNotInFlight = errors.New("message is not in flight")
+
+var ErrQueueNotFound = errors.New("queue not found")
+
+var ErrMessageLimitExceeded = errors.New("queue message limit exceeded")
+
+var ErrByteLimitExceeded = errors.New("queue byte limit exceeded")
+
+var ErrMessageNotFound = errors.New("message not found")

--- a/handlers_ack.go
+++ b/handlers_ack.go
@@ -1,13 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"net/http"
-	"time"
-
-	"github.com/cockroachdb/pebble/v2"
+	"strings"
 )
 
 func ack(w http.ResponseWriter, r *http.Request) {
@@ -22,14 +21,12 @@ func ack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try batch ack first
 	var batchReq BatchAckRequest
 	if json.Unmarshal(body, &batchReq) == nil && len(batchReq.Acks) > 0 {
 		handleBatchAck(w, batchReq)
 		return
 	}
 
-	// Fall back to single ack
 	var ackReq AckRequest
 	if err := json.Unmarshal(body, &ackReq); err != nil {
 		http.Error(w, "Bad Request: "+err.Error(), http.StatusBadRequest)
@@ -49,56 +46,14 @@ func ack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	batch := Db.NewIndexedBatch()
-	defer batch.Close()
-	if _, closer, err := batch.Get([]byte(ackReq.QueueId)); err != nil {
-		batch.Close()
-		if err == pebble.ErrNotFound {
-			http.Error(w, "Queue or message not found", http.StatusNotFound)
-			return
-		}
-		http.Error(w, "Failed to acknowledge message: "+err.Error(), http.StatusInternalServerError)
-		return
-	} else {
-		closer.Close()
-	}
-	key, msg, err := messageByReceiptHandle(batch, ackReq.QueueId, ackReq.ReceiptHandle)
-	if err != nil {
-		batch.Close()
-		if _, ok := err.(*ErrInvalidReceiptHandle); ok {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if err == pebble.ErrNotFound {
-			http.Error(w, "Queue or message not found", http.StatusNotFound)
-			return
-		}
-		http.Error(w, "Failed to acknowledge message: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if msg.State != StateInFlight {
-		batch.Close()
-		http.Error(w, ErrMessageNotInFlight.Error(), http.StatusConflict)
-		return
-	}
-	if msg.DeliveryAttemptID != ackReq.DeliveryToken {
-		batch.Close()
-		http.Error(w, (&ErrDeliveryTokenMismatch{Expected: msg.DeliveryAttemptID, Got: ackReq.DeliveryToken}).Error(), http.StatusConflict)
-		return
-	}
-	if err := deleteInflightIndex(batch, ackReq.QueueId, *msg); err != nil {
-		batch.Close()
-		http.Error(w, "Failed to acknowledge message: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	deleteCachedMessageKey(ackReq.ReceiptHandle)
-	if err := batch.Delete(key, nil); err != nil {
-		batch.Close()
-		http.Error(w, "Failed to acknowledge message: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if err := batch.Commit(pebble.NoSync); err != nil {
-		http.Error(w, "Failed to acknowledge message: "+err.Error(), http.StatusInternalServerError)
+	results := QueueManager.AckBatch(r.Context(), ackReq.QueueId, []AckEntry{{
+		MessageId:     ackReq.MessageId,
+		ReceiptHandle: ackReq.ReceiptHandle,
+		DeliveryToken: ackReq.DeliveryToken,
+	}})
+	res := results[0]
+	if res.Status != "ok" {
+		respondAckError(w, ackReq.QueueId, res.Error)
 		return
 	}
 
@@ -107,9 +62,6 @@ func ack(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{
 		"message": "Message Acknowledged and removed from queue",
 	})
-
-	m := getOrCreateMetrics(ackReq.QueueId)
-	m.recordAck()
 }
 
 func handleBatchAck(w http.ResponseWriter, batchReq BatchAckRequest) {
@@ -118,6 +70,17 @@ func handleBatchAck(w http.ResponseWriter, batchReq BatchAckRequest) {
 		return
 	}
 
+	if _, err := QueueManager.getQueue(batchReq.QueueId); err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			http.Error(w, "Queue not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "Failed to acknowledge: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	results := QueueManager.AckBatch(context.Background(), batchReq.QueueId, batchReq.Acks)
+
 	type batchAckResult struct {
 		MessageId     string `json:"messageId,omitempty"`
 		ReceiptHandle string `json:"receiptHandle,omitempty"`
@@ -125,71 +88,20 @@ func handleBatchAck(w http.ResponseWriter, batchReq BatchAckRequest) {
 		Error         string `json:"error,omitempty"`
 	}
 
-	results := make([]batchAckResult, len(batchReq.Acks))
-
-	batch := Db.NewIndexedBatch()
-	defer batch.Close()
-	if _, closer, err := batch.Get([]byte(batchReq.QueueId)); err != nil {
-		if err == pebble.ErrNotFound {
-			http.Error(w, "Queue not found", http.StatusNotFound)
-			return
-		}
-		http.Error(w, "Failed to acknowledge: "+err.Error(), http.StatusInternalServerError)
-		return
-	} else {
-		closer.Close()
-	}
-
-	for i, entry := range batchReq.Acks {
-		results[i].MessageId = entry.MessageId
-		results[i].ReceiptHandle = entry.ReceiptHandle
-
-		key, msg, err := messageByReceiptHandle(batch, batchReq.QueueId, entry.ReceiptHandle)
-		if err != nil {
-			results[i].Status = "error"
-			results[i].Error = fmt.Sprintf("message not found: %v", err)
-			continue
-		}
-		results[i].MessageId = msg.ID
-		if msg.State != StateInFlight {
-			results[i].Status = "error"
-			results[i].Error = ErrMessageNotInFlight.Error()
-			continue
-		}
-		if msg.DeliveryAttemptID != entry.DeliveryToken {
-			results[i].Status = "error"
-			results[i].Error = fmt.Sprintf("delivery token mismatch: expected %q, got %q", msg.DeliveryAttemptID, entry.DeliveryToken)
-			continue
-		}
-		if err := deleteInflightIndex(batch, batchReq.QueueId, *msg); err != nil {
-			results[i].Status = "error"
-			results[i].Error = fmt.Sprintf("delete in-flight index failed: %v", err)
-			continue
-		}
-		if err := batch.Delete(key, nil); err != nil {
-			results[i].Status = "error"
-			results[i].Error = fmt.Sprintf("delete failed: %v", err)
-			continue
-		}
-		deleteCachedMessageKey(entry.ReceiptHandle)
-		results[i].Status = "ok"
-	}
-	if err := batch.Commit(pebble.NoSync); err != nil {
-		http.Error(w, "Failed to acknowledge: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	m := getOrCreateMetrics(batchReq.QueueId)
-	for _, res := range results {
-		if res.Status == "ok" {
-			m.recordAck()
+	out := make([]batchAckResult, len(results))
+	for i, res := range results {
+		out[i] = batchAckResult{
+			MessageId:     res.MessageID,
+			ReceiptHandle: res.ReceiptHandle,
+			Status:        res.Status,
+			Error:         res.Error,
 		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(map[string]any{
-		"results": results,
+		"results": out,
 	})
 }
 
@@ -224,6 +136,19 @@ func ackBatch(w http.ResponseWriter, r *http.Request) {
 	handleBatchAck(w, req)
 }
 
+func respondAckError(w http.ResponseWriter, queueID, errMsg string) {
+	switch {
+	case strings.Contains(errMsg, "queue not found"):
+		http.Error(w, "Queue or message not found", http.StatusNotFound)
+	case strings.Contains(errMsg, "receipt handle not found") || strings.Contains(errMsg, "duplicate receipt handle"):
+		http.Error(w, "invalid receipt handle: "+errMsg, http.StatusBadRequest)
+	case strings.Contains(errMsg, "delivery token mismatch"):
+		http.Error(w, errMsg, http.StatusConflict)
+	default:
+		http.Error(w, "Failed to acknowledge message: "+errMsg, http.StatusInternalServerError)
+	}
+}
+
 func nack(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Only POST allowed", http.StatusMethodNotAllowed)
@@ -249,117 +174,33 @@ func nack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var nackResultState MessageState
-	var needReadyPointer bool
-
-	batch := Db.NewIndexedBatch()
-	defer batch.Close()
-	if _, closer, err := batch.Get([]byte(ackReq.QueueId)); err != nil {
-		batch.Close()
-		if err == pebble.ErrNotFound {
-			http.Error(w, "Queue or message not found", http.StatusNotFound)
-			return
-		}
-		http.Error(w, "Failed to nack message: "+err.Error(), http.StatusInternalServerError)
-		return
-	} else {
-		closer.Close()
-	}
-
-	key, msg, err := messageByReceiptHandle(batch, ackReq.QueueId, ackReq.ReceiptHandle)
+	state, err := QueueManager.Nack(r.Context(), ackReq.QueueId, ackReq.ReceiptHandle, ackReq.DeliveryToken)
 	if err != nil {
-		batch.Close()
-		if _, ok := err.(*ErrInvalidReceiptHandle); ok {
+		var tokenMismatch *ErrDeliveryTokenMismatch
+		var invalidHandle *ErrInvalidReceiptHandle
+		switch {
+		case errors.Is(err, ErrQueueNotFound):
+			http.Error(w, "Queue or message not found", http.StatusNotFound)
+		case errors.As(err, &invalidHandle):
 			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if err == pebble.ErrNotFound {
+		case errors.Is(err, ErrMessageNotFound):
 			http.Error(w, "Queue or message not found", http.StatusNotFound)
-			return
-		}
-		http.Error(w, "Failed to nack message: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if msg.State != StateInFlight {
-		batch.Close()
-		http.Error(w, ErrMessageNotInFlight.Error(), http.StatusConflict)
-		return
-	}
-	if msg.DeliveryAttemptID != ackReq.DeliveryToken {
-		batch.Close()
-		http.Error(w, (&ErrDeliveryTokenMismatch{Expected: msg.DeliveryAttemptID, Got: ackReq.DeliveryToken}).Error(), http.StatusConflict)
-		return
-	}
-	if err := deleteInflightIndex(batch, ackReq.QueueId, *msg); err != nil {
-		batch.Close()
-		http.Error(w, "Failed to nack message: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
-		msg.State = StateDead
-	} else {
-		msg.State = StateReady
-	}
-	msg.VisibilityDeadline = time.Time{}
-	msg.DeliveryAttemptID = ""
-
-	nackResultState = msg.State
-	needReadyPointer = nackResultState == StateReady
-
-	updated, err := json.Marshal(msg)
-	if err != nil {
-		batch.Close()
-		http.Error(w, "Failed to nack message: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if err := batch.Set(key, updated, nil); err != nil {
-		batch.Close()
-		http.Error(w, "Failed to nack message: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if needReadyPointer {
-		newSeq, err := nextMessageSequence(ackReq.QueueId)
-		if err != nil {
-			batch.Close()
-			http.Error(w, fmt.Sprintf("allocate nack sequence: %v", err), http.StatusInternalServerError)
-			return
-		}
-		if err := batch.Set(readyKey(ackReq.QueueId, newSeq, msg.ID), readyValue(key), nil); err != nil {
-			batch.Close()
+		case errors.As(err, &tokenMismatch):
+			http.Error(w, err.Error(), http.StatusConflict)
+		default:
 			http.Error(w, "Failed to nack message: "+err.Error(), http.StatusInternalServerError)
-			return
 		}
-		cacheMessageKey(ackReq.ReceiptHandle, key)
-	} else {
-		deleteCachedMessageKey(ackReq.ReceiptHandle)
-	}
-
-	if err := batch.Commit(pebble.NoSync); err != nil {
-		http.Error(w, "Failed to nack message: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	if state == StateReady {
+		signalQueueReady(ackReq.QueueId)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(map[string]any{
 		"message": "Message Nacked and state updated",
-		"state":   nackResultState,
+		"state":   state,
 	})
-
-	if needReadyPointer {
-		signalQueueReady(ackReq.QueueId)
-	}
-
-	m := getOrCreateMetrics(ackReq.QueueId)
-	m.totalNacked.Add(1)
-	m.inFlightCount.Add(-1)
-	if nackResultState == StateReady {
-		m.readyCount.Add(1)
-	} else if nackResultState == StateDead {
-		m.deadCount.Add(1)
-	}
-
 }

--- a/handlers_ack.go
+++ b/handlers_ack.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -23,7 +22,7 @@ func ack(w http.ResponseWriter, r *http.Request) {
 
 	var batchReq BatchAckRequest
 	if json.Unmarshal(body, &batchReq) == nil && len(batchReq.Acks) > 0 {
-		handleBatchAck(w, batchReq)
+		handleBatchAck(w, r, batchReq)
 		return
 	}
 
@@ -64,7 +63,7 @@ func ack(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func handleBatchAck(w http.ResponseWriter, batchReq BatchAckRequest) {
+func handleBatchAck(w http.ResponseWriter, r *http.Request, batchReq BatchAckRequest) {
 	if batchReq.QueueId == "" {
 		http.Error(w, "queueId is required", http.StatusBadRequest)
 		return
@@ -79,7 +78,7 @@ func handleBatchAck(w http.ResponseWriter, batchReq BatchAckRequest) {
 		return
 	}
 
-	results := QueueManager.AckBatch(context.Background(), batchReq.QueueId, batchReq.Acks)
+	results := QueueManager.AckBatch(r.Context(), batchReq.QueueId, batchReq.Acks)
 
 	type batchAckResult struct {
 		MessageId     string `json:"messageId,omitempty"`
@@ -133,7 +132,7 @@ func ackBatch(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	handleBatchAck(w, req)
+	handleBatchAck(w, r, req)
 }
 
 func respondAckError(w http.ResponseWriter, queueID, errMsg string) {

--- a/handlers_publish.go
+++ b/handlers_publish.go
@@ -2,11 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
-	"time"
-
-	"github.com/cockroachdb/pebble/v2"
-	"github.com/google/uuid"
 )
 
 func publish(w http.ResponseWriter, r *http.Request) {
@@ -14,83 +11,27 @@ func publish(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Only POST allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	// publish should , 1. take task 2. put it in queue 3. return id
 	var message PublishRequest
 
-	err := json.NewDecoder(r.Body).Decode(&message)
-	if err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&message); err != nil {
 		http.Error(w, "Bad Request : "+err.Error(), http.StatusBadRequest)
+		return
 	}
 
-	queueId := message.QueueId
-	var queueConfig QueueConfig
-	val, closer, err := Db.Get([]byte(queueId))
+	ids, err := QueueManager.PublishBatch(r.Context(), message.QueueId, [][]byte{message.Message.Body})
 	if err != nil {
-		if err == pebble.ErrNotFound {
-			http.Error(w, "Queue Not Found for id: "+queueId, http.StatusNotFound)
-			return
-		}
-		http.Error(w, "Error retrieving queue: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if err := json.Unmarshal(val, &queueConfig); err != nil {
-		http.Error(w, "Error decoding queue: "+err.Error(), http.StatusInternalServerError)
-		closer.Close()
-		return
-	}
-	closer.Close()
-
-	// push to queue and return id
-	seq, err := nextMessageSequence(queueId)
-	if err != nil {
-		http.Error(w, "Error Allocating Message Sequence: "+err.Error(), http.StatusInternalServerError)
+		respondPublishError(w, err)
 		return
 	}
 
-	message.Message.ID = uuid.NewString()
-	message.Message.State = StateReady
-	message.Message.EnqueuedAt = time.Now()
-	message.Message.MaxDeliveryCount = queueConfig.MaxRetries
-
-	messageJson, err := json.Marshal(message.Message)
-	if err != nil {
-		http.Error(w, "Bad Reqeust: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	msgKey := messageKey(queueId, seq, message.Message.ID)
-	err = func() error {
-		batch := Db.NewIndexedBatch()
-		defer batch.Close()
-		if err := batch.Set(msgKey, messageJson, nil); err != nil {
-			return err
-		}
-		cacheMessageKey(receiptHandleForMessageKey(msgKey), msgKey)
-		if err := batch.Set(readyKey(queueId, seq, message.Message.ID), readyValue(msgKey), nil); err != nil {
-			return err
-		}
-		return batch.Commit(pebble.NoSync)
-	}()
-	if err != nil {
-		http.Error(w, "Error Saving Message: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// queue.Messages = append(queue.Messages, message.Message)
-
-	signalQueueReady(queueId)
-
-	m := getOrCreateMetrics(queueId)
-	m.totalPublished.Add(1)
-	m.readyCount.Add(1)
+	signalQueueReady(message.QueueId)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(map[string]any{
-		"id":    message.Message.ID,
+		"id":    ids[0],
 		"state": StateReady,
 	})
-
 }
 
 func publishBatch(w http.ResponseWriter, r *http.Request) {
@@ -112,70 +53,31 @@ func publishBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var queueConfig QueueConfig
-	val, closer, err := Db.Get([]byte(req.QueueId))
-	if err != nil {
-		if err == pebble.ErrNotFound {
-			http.Error(w, "Queue Not Found for id: "+req.QueueId, http.StatusNotFound)
-			return
-		}
-		http.Error(w, "Error retrieving queue: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if err := json.Unmarshal(val, &queueConfig); err != nil {
-		http.Error(w, "Error decoding queue: "+err.Error(), http.StatusInternalServerError)
-		closer.Close()
-		return
-	}
-	closer.Close()
-
-	ids := make([]string, len(req.Messages))
-	now := time.Now()
-
-	seqs, err := nextMessageSequenceN(req.QueueId, len(req.Messages))
-	if err != nil {
-		http.Error(w, "Error Allocating Message Sequences: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	batch := Db.NewIndexedBatch()
-	defer batch.Close()
+	bodies := make([][]byte, len(req.Messages))
 	for i, msg := range req.Messages {
-		msg.ID = uuid.NewString()
-		msg.State = StateReady
-		msg.EnqueuedAt = now
-		msg.MaxDeliveryCount = queueConfig.MaxRetries
-
-		msgJson, err := json.Marshal(msg)
-		if err != nil {
-			http.Error(w, "Error encoding message: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		msgKey := messageKey(req.QueueId, seqs[i], msg.ID)
-		if err := batch.Set(msgKey, msgJson, nil); err != nil {
-			http.Error(w, "Error Saving Messages: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		cacheMessageKey(receiptHandleForMessageKey(msgKey), msgKey)
-		if err := batch.Set(readyKey(req.QueueId, seqs[i], msg.ID), readyValue(msgKey), nil); err != nil {
-			http.Error(w, "Error Saving Messages: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		ids[i] = msg.ID
+		bodies[i] = msg.Body
 	}
-	if err := batch.Commit(pebble.NoSync); err != nil {
-		http.Error(w, "Error Saving Messages: "+err.Error(), http.StatusInternalServerError)
+
+	ids, err := QueueManager.PublishBatch(r.Context(), req.QueueId, bodies)
+	if err != nil {
+		respondPublishError(w, err)
 		return
 	}
 
 	signalQueueReady(req.QueueId)
 
-	m := getOrCreateMetrics(req.QueueId)
-	m.totalPublished.Add(int64(len(ids)))
-	m.readyCount.Add(int64(len(ids)))
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(BatchPublishResponse{IDs: ids})
+}
+
+func respondPublishError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrQueueNotFound):
+		http.Error(w, "Queue Not Found", http.StatusNotFound)
+	case errors.Is(err, ErrMessageLimitExceeded), errors.Is(err, ErrByteLimitExceeded):
+		http.Error(w, err.Error(), http.StatusTooManyRequests)
+	default:
+		http.Error(w, "Error Saving Message: "+err.Error(), http.StatusInternalServerError)
+	}
 }

--- a/handlers_queue.go
+++ b/handlers_queue.go
@@ -25,7 +25,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 	var publishRequest CreateRequest
 
 	if err := json.NewDecoder(r.Body).Decode(&publishRequest); err != nil {
-		http.Error(w, "Bad Requst Error: "+err.Error(), http.StatusBadRequest)
+		http.Error(w, "Bad Request Error: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -71,7 +71,7 @@ func getQueue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
+	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]any{
 		"id":   id,
 		"name": q.config.Name,

--- a/handlers_queue.go
+++ b/handlers_queue.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"net/http"
-
-	"github.com/cockroachdb/pebble/v2"
-	"github.com/google/uuid"
 )
 
 func queueHandler(w http.ResponseWriter, r *http.Request) {
@@ -27,41 +24,21 @@ func create(w http.ResponseWriter, r *http.Request) {
 	}
 	var publishRequest CreateRequest
 
-	err := json.NewDecoder(r.Body).Decode(&publishRequest)
-
-	if err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&publishRequest); err != nil {
 		http.Error(w, "Bad Requst Error: "+err.Error(), http.StatusBadRequest)
-
+		return
 	}
 
-	queue := Queue{
-		Id:         uuid.NewString(),
-		Name:       publishRequest.Name,
-		MaxRetries: publishRequest.MaxRetries,
-	}
-
-	err = func() error {
-		batch := Db.NewIndexedBatch()
-		defer batch.Close()
-		config, err := json.Marshal(QueueConfig{Name: queue.Name, MaxRetries: queue.MaxRetries})
-		if err != nil {
-			return err
-		}
-		if err := batch.Set([]byte(queue.Id), config, nil); err != nil {
-			return err
-		}
-		return batch.Commit(pebble.NoSync)
-	}()
+	queueID, err := QueueManager.CreateQueue(r.Context(), publishRequest.Name, publishRequest.MaxRetries)
 	if err != nil {
 		http.Error(w, "Failed to create queue: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	// 	Queues = append(Queues, queue)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(map[string]any{
-		"id":    queue.Id,
+		"id":    queueID,
 		"state": StateReady,
 	})
 }
@@ -80,31 +57,23 @@ func getQueue(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"Error": "id is required in the url",
 		})
+		return
 	}
 
-	//get from db
-
-	val, closer, err := Db.Get([]byte(id))
+	q, err := QueueManager.getQueue(id)
 	if err != nil {
-		if err == pebble.ErrNotFound {
+		if errors.Is(err, ErrQueueNotFound) {
 			http.Error(w, "Queue Not Found for id: "+id, http.StatusNotFound)
 			return
 		}
-		log.Println(err)
 		http.Error(w, "Error retrieving queue: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	defer closer.Close()
-	var config QueueConfig
-	if err := json.Unmarshal(val, &config); err != nil {
-		http.Error(w, "Error decoding queue config: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(map[string]any{
 		"id":   id,
-		"name": config.Name,
+		"name": q.config.Name,
 	})
-
 }

--- a/handlers_receive.go
+++ b/handlers_receive.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -14,6 +16,199 @@ import (
 )
 
 var claimMu sync.Mutex
+
+func claimWithWait(ctx context.Context, id string, max int, wait bool) ([]claimedMessage, error) {
+	msgs, err := QueueManager.ClaimBatch(ctx, id, max)
+	if err == nil {
+		return msgs, nil
+	}
+	if !errors.Is(err, ErrNoReadyMessages) {
+		return nil, err
+	}
+	if !wait {
+		return nil, ErrNoReadyMessages
+	}
+
+	readyCh := queueReadyChan(id)
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+	for {
+		msgs, err := QueueManager.ClaimBatch(ctx, id, max)
+		if err == nil {
+			return msgs, nil
+		}
+		if !errors.Is(err, ErrNoReadyMessages) {
+			return nil, err
+		}
+		select {
+		case <-readyCh:
+			readyCh = queueReadyChan(id)
+			continue
+		case <-timer.C:
+			return nil, ErrNoReadyMessages
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func receive(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Only GET allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	params := r.URL.Query()
+	id := params.Get("id")
+	if id == "" {
+		http.Error(w, "id is required in the url", http.StatusBadRequest)
+		return
+	}
+
+	if _, err := QueueManager.getQueue(id); err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			http.Error(w, "Queue Not Found for id: "+id, http.StatusNotFound)
+			return
+		}
+		log.Println(err)
+		http.Error(w, "Error retrieving queue: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	max := 1
+	maxSpecified := false
+	if maxStr := params.Get("max"); maxStr != "" {
+		parsed, parseErr := strconv.Atoi(maxStr)
+		if parseErr != nil || parsed < 1 || parsed > 100 {
+			http.Error(w, "max must be an integer between 1 and 100", http.StatusBadRequest)
+			return
+		}
+		max = parsed
+		maxSpecified = true
+	}
+
+	wait := params.Get("wait") == "true"
+
+	if max == 1 && !maxSpecified {
+		msgs, err := claimWithWait(r.Context(), id, 1, wait)
+		if err != nil {
+			if errors.Is(err, ErrNoReadyMessages) {
+				http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
+				return
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+			http.Error(w, "Error retrieving message: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		msg := msgs[0]
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":            msg.ID,
+			"body":          msg.Body,
+			"state":         StateInFlight,
+			"deliveryToken": msg.DeliveryAttemptID,
+			"receiptHandle": msg.ReceiptHandle,
+		})
+		return
+	}
+
+	msgs, err := claimWithWait(r.Context(), id, max, wait)
+	if err != nil {
+		if errors.Is(err, ErrNoReadyMessages) {
+			http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		http.Error(w, "Error retrieving messages: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	batch := make([]batchReceiveMessage, 0, len(msgs))
+	for _, msg := range msgs {
+		batch = append(batch, batchReceiveMessage{
+			ID:            msg.ID,
+			Body:          msg.Body,
+			State:         StateInFlight,
+			DeliveryToken: msg.DeliveryAttemptID,
+			ReceiptHandle: msg.ReceiptHandle,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(map[string]any{
+		"messages": batch,
+	})
+}
+
+func receiveBatch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Only GET allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	params := r.URL.Query()
+	id := params.Get("id")
+	if id == "" {
+		http.Error(w, "id is required in the url", http.StatusBadRequest)
+		return
+	}
+
+	max := 1
+	if m := params.Get("max"); m != "" {
+		if v, err := strconv.Atoi(m); err == nil && v > 0 {
+			max = v
+		}
+	}
+
+	if _, err := QueueManager.getQueue(id); err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			http.Error(w, "Queue Not Found for id: "+id, http.StatusNotFound)
+			return
+		}
+		log.Println(err)
+		http.Error(w, "Error retrieving queue: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	wait := params.Get("wait") == "true"
+
+	msgs, err := claimWithWait(r.Context(), id, max, wait)
+	if err != nil {
+		if errors.Is(err, ErrNoReadyMessages) {
+			http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		http.Error(w, "Error retrieving messages: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := batchReceiveResponse{Messages: make([]batchReceiveMessage, len(msgs))}
+	for i, msg := range msgs {
+		resp.Messages[i] = batchReceiveMessage{
+			ID:            msg.ID,
+			Body:          msg.Body,
+			State:         msg.State,
+			DeliveryToken: msg.DeliveryAttemptID,
+			ReceiptHandle: msg.ReceiptHandle,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(resp)
+}
+
+// Legacy Pebble-based claim path. Retained for benchmark compatibility while
+// the live handlers route through queueManager.ClaimBatch. Pending removal in
+// Phase 2.10.
 
 func claimNextReadyMessage(queueId string) (*claimedMessage, error) {
 	msgs, err := claimReadyMessages(queueId, 1)
@@ -126,279 +321,4 @@ func claimReadyMessages(queueId string, max int) ([]claimedMessage, error) {
 		return nil, fmt.Errorf("commit claim batch: %w", err)
 	}
 	return claimed, nil
-}
-
-func receive(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "Only GET allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	params := r.URL.Query()
-	id := params.Get("id")
-	if id == "" {
-		http.Error(w, "id is required in the url", http.StatusBadRequest)
-		return
-	}
-
-	// verify queue exists
-	_, closer, err := Db.Get([]byte(id))
-	if err != nil {
-		if err == pebble.ErrNotFound {
-			http.Error(w, "Queue Not Found for id: "+id, http.StatusNotFound)
-			return
-		}
-		log.Println(err)
-		http.Error(w, "Error retrieving queue: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	closer.Close()
-
-	max := 1
-	maxSpecified := false
-	if maxStr := params.Get("max"); maxStr != "" {
-		parsed, parseErr := strconv.Atoi(maxStr)
-		if parseErr != nil || parsed < 1 || parsed > 100 {
-			http.Error(w, "max must be an integer between 1 and 100", http.StatusBadRequest)
-			return
-		}
-		max = parsed
-		maxSpecified = true
-	}
-
-	if max == 1 && !maxSpecified {
-		var msg *claimedMessage
-		var claimErr error
-
-		if wait := params.Get("wait"); wait == "true" {
-			msg, claimErr = claimNextReadyMessage(id)
-			if claimErr != nil && claimErr != ErrNoReadyMessages {
-				http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
-				return
-			}
-			if claimErr == ErrNoReadyMessages {
-				readyCh := queueReadyChan(id)
-				timer := time.NewTimer(30 * time.Second)
-				defer timer.Stop()
-			waitLoop:
-				for {
-					msg, claimErr = claimNextReadyMessage(id)
-					if claimErr == nil {
-						break
-					}
-					if claimErr != nil && claimErr != ErrNoReadyMessages {
-						http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
-						return
-					}
-					select {
-					case <-readyCh:
-						readyCh = queueReadyChan(id)
-						continue
-					case <-timer.C:
-						break waitLoop
-					case <-r.Context().Done():
-						return
-					}
-				}
-			}
-		} else {
-			msg, claimErr = claimNextReadyMessage(id)
-		}
-
-		if claimErr != nil && claimErr != ErrNoReadyMessages {
-			http.Error(w, "Error retrieving message: "+claimErr.Error(), http.StatusInternalServerError)
-			return
-		}
-		if claimErr == ErrNoReadyMessages || msg == nil {
-			http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
-			return
-		}
-
-		m := getOrCreateMetrics(id)
-		m.totalReceived.Add(1)
-		m.readyCount.Add(-1)
-		m.inFlightCount.Add(1)
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusAccepted)
-		json.NewEncoder(w).Encode(map[string]any{
-			"id":            msg.ID,
-			"body":          msg.Body,
-			"state":         StateInFlight,
-			"deliveryToken": msg.DeliveryAttemptID,
-			"receiptHandle": msg.ReceiptHandle,
-		})
-		return
-	}
-
-	// batch receive (max > 1)
-	msgs, claimErr := claimReadyMessages(id, max)
-	if claimErr != nil && claimErr != ErrNoReadyMessages {
-		http.Error(w, "Error retrieving messages: "+claimErr.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if wait := params.Get("wait"); wait == "true" {
-		if len(msgs) == 0 {
-			readyCh := queueReadyChan(id)
-			timer := time.NewTimer(30 * time.Second)
-			defer timer.Stop()
-		waitLoopBatch:
-			for {
-				msgs, claimErr = claimReadyMessages(id, max)
-				if claimErr != nil && claimErr != ErrNoReadyMessages {
-					http.Error(w, "Error retrieving messages: "+claimErr.Error(), http.StatusInternalServerError)
-					return
-				}
-				if len(msgs) > 0 {
-					break
-				}
-				select {
-				case <-readyCh:
-					readyCh = queueReadyChan(id)
-					continue
-				case <-timer.C:
-					break waitLoopBatch
-				case <-r.Context().Done():
-					return
-				}
-			}
-		}
-	}
-
-	if len(msgs) == 0 {
-		http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
-		return
-	}
-
-	type batchMessage struct {
-		ID            string       `json:"id"`
-		Body          []byte       `json:"body"`
-		State         MessageState `json:"state"`
-		DeliveryToken string       `json:"deliveryToken"`
-		ReceiptHandle string       `json:"receiptHandle"`
-	}
-	batch := make([]batchMessage, 0, len(msgs))
-	for _, msg := range msgs {
-		batch = append(batch, batchMessage{
-			ID:            msg.ID,
-			Body:          msg.Body,
-			State:         StateInFlight,
-			DeliveryToken: msg.DeliveryAttemptID,
-			ReceiptHandle: msg.ReceiptHandle,
-		})
-	}
-
-	m := getOrCreateMetrics(id)
-	for range msgs {
-		m.totalReceived.Add(1)
-		m.readyCount.Add(-1)
-		m.inFlightCount.Add(1)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	json.NewEncoder(w).Encode(map[string]any{
-		"messages": batch,
-	})
-}
-
-func receiveBatch(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "Only GET allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	params := r.URL.Query()
-	id := params.Get("id")
-	if id == "" {
-		http.Error(w, "id is required in the url", http.StatusBadRequest)
-		return
-	}
-
-	max := 1
-	if m := params.Get("max"); m != "" {
-		if v, err := strconv.Atoi(m); err == nil && v > 0 {
-			max = v
-		}
-	}
-
-	_, closer, err := Db.Get([]byte(id))
-	if err != nil {
-		if err == pebble.ErrNotFound {
-			http.Error(w, "Queue Not Found for id: "+id, http.StatusNotFound)
-			return
-		}
-		log.Println(err)
-		http.Error(w, "Error retrieving queue: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	closer.Close()
-
-	var msgs []claimedMessage
-	var claimErr error
-
-	if wait := params.Get("wait"); wait == "true" {
-		msgs, claimErr = claimReadyMessages(id, max)
-		if claimErr != nil && claimErr != ErrNoReadyMessages {
-			http.Error(w, "Error retrieving messages: "+claimErr.Error(), http.StatusInternalServerError)
-			return
-		}
-		if claimErr == ErrNoReadyMessages || len(msgs) == 0 {
-			readyCh := queueReadyChan(id)
-			timer := time.NewTimer(30 * time.Second)
-			defer timer.Stop()
-		waitLoop:
-			for {
-				msgs, claimErr = claimReadyMessages(id, max)
-				if claimErr == nil && len(msgs) > 0 {
-					break
-				}
-				if claimErr != nil && claimErr != ErrNoReadyMessages {
-					http.Error(w, "Error retrieving messages: "+claimErr.Error(), http.StatusInternalServerError)
-					return
-				}
-				select {
-				case <-readyCh:
-					readyCh = queueReadyChan(id)
-					continue
-				case <-timer.C:
-					break waitLoop
-				case <-r.Context().Done():
-					return
-				}
-			}
-		}
-	} else {
-		msgs, claimErr = claimReadyMessages(id, max)
-	}
-
-	if claimErr != nil && claimErr != ErrNoReadyMessages {
-		http.Error(w, "Error retrieving messages: "+claimErr.Error(), http.StatusInternalServerError)
-		return
-	}
-	if claimErr == ErrNoReadyMessages || len(msgs) == 0 {
-		http.Error(w, "No Ready Messages in Queue: "+id, http.StatusNotFound)
-		return
-	}
-
-	m := getOrCreateMetrics(id)
-	for range msgs {
-		m.totalReceived.Add(1)
-		m.readyCount.Add(-1)
-		m.inFlightCount.Add(1)
-	}
-
-	resp := batchReceiveResponse{Messages: make([]batchReceiveMessage, len(msgs))}
-	for i, msg := range msgs {
-		resp.Messages[i] = batchReceiveMessage{
-			ID:            msg.ID,
-			Body:          msg.Body,
-			State:         msg.State,
-			DeliveryToken: msg.DeliveryAttemptID,
-			ReceiptHandle: msg.ReceiptHandle,
-		}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	json.NewEncoder(w).Encode(resp)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -190,7 +190,7 @@ func TestCreateAndGetQueue(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	getQueue(recorder, req)
 
-	if recorder.Code != http.StatusAccepted {
+	if recorder.Code != http.StatusOK {
 		t.Fatalf("get status = %d, body = %s", recorder.Code, recorder.Body.String())
 	}
 
@@ -1626,7 +1626,9 @@ func TestCreatePublishAPICompatibility(t *testing.T) {
 		ID    string       `json:"id"`
 		State MessageState `json:"state"`
 	}
-	json.NewDecoder(rec.Body).Decode(&pr)
+	if err := json.NewDecoder(rec.Body).Decode(&pr); err != nil {
+		t.Fatalf("decode publish response: %v", err)
+	}
 	if pr.ID == "" {
 		t.Fatal("publish returned empty id")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -35,9 +35,18 @@ func setupTestDB(t *testing.T) {
 	messageKeyCache = sync.Map{}
 	deliveryRecordSeq.Store(0)
 
+	qm, wal, err := initQueueManagerFromEnv(context.Background(), db)
+	if err != nil {
+		t.Fatalf("init queue manager: %v", err)
+	}
+	QueueManager = qm
+	WAL = wal
+
 	t.Cleanup(func() {
 		_ = db.Close()
 		Db = nil
+		QueueManager = nil
+		WAL = nil
 	})
 }
 
@@ -117,6 +126,17 @@ func storedMessageKey(t *testing.T, queueID, messageID string) []byte {
 	}
 
 	return key
+}
+
+func runtimeQueueState(t *testing.T, queueID string) (ready, inflight, dead int) {
+	t.Helper()
+	q, err := QueueManager.getQueue(queueID)
+	if err != nil {
+		t.Fatalf("get queue: %v", err)
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.ready.Len(), len(q.inflight), len(q.dead)
 }
 
 type receiveResponse struct {
@@ -211,7 +231,6 @@ func TestPublishReceiveAck(t *testing.T) {
 		t.Fatal("expected non-empty receipt handle")
 	}
 
-	storedKey := storedMessageKey(t, queueID, messageID)
 	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: resp.ReceiptHandle, DeliveryToken: resp.DeliveryToken})
 	if err != nil {
 		t.Fatalf("marshal ack request: %v", err)
@@ -225,12 +244,25 @@ func TestPublishReceiveAck(t *testing.T) {
 		t.Fatalf("ack status = %d, body = %s", ackRecorder.Code, ackRecorder.Body.String())
 	}
 
-	_, closer, err := Db.Get(storedKey)
-	if closer != nil {
-		closer.Close()
+	// Message must be gone from the runtime: a second receive returns 404 and
+	// a second ack on the same handle is rejected.
+	secondReq := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID, nil)
+	secondRecorder := httptest.NewRecorder()
+	receive(secondRecorder, secondReq)
+	if secondRecorder.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after ack, got %d: %s", secondRecorder.Code, secondRecorder.Body.String())
 	}
-	if err != pebble.ErrNotFound {
-		t.Fatalf("expected message to be deleted after ack, got %v", err)
+
+	dupAckReq := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(ackBody))
+	dupAckRecorder := httptest.NewRecorder()
+	ack(dupAckRecorder, dupAckReq)
+	if dupAckRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for duplicate ack, got %d: %s", dupAckRecorder.Code, dupAckRecorder.Body.String())
+	}
+
+	ready, inflight, dead := runtimeQueueState(t, queueID)
+	if ready != 0 || inflight != 0 || dead != 0 {
+		t.Fatalf("after ack: ready=%d inflight=%d dead=%d, want all 0", ready, inflight, dead)
 	}
 }
 
@@ -559,26 +591,9 @@ func TestAckDeletesInflightIndex(t *testing.T) {
 
 	resp := receiveTestMessage(t, queueID)
 
-	key, err := messageKeyFromReceiptHandle(queueID, resp.ReceiptHandle)
-	if err != nil {
-		t.Fatalf("message key from receipt handle: %v", err)
-	}
-	val, closer, err := Db.Get(key)
-	if err != nil {
-		t.Fatalf("get message: %v", err)
-	}
-	var msg Message
-	if err := json.Unmarshal(val, &msg); err != nil {
-		closer.Close()
-		t.Fatalf("unmarshal message: %v", err)
-	}
-	closer.Close()
-	_, closer, err = Db.Get(inflightKey(queueID, msg.VisibilityDeadline, msg.ID))
-	if closer != nil {
-		closer.Close()
-	}
-	if err != nil {
-		t.Fatalf("expected in-flight index after receive: %v", err)
+	// After receive the message is in-flight in the runtime.
+	if _, inflight, _ := runtimeQueueState(t, queueID); inflight != 1 {
+		t.Fatalf("expected 1 in-flight after receive, got %d", inflight)
 	}
 
 	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: resp.ReceiptHandle, DeliveryToken: resp.DeliveryToken})
@@ -592,14 +607,18 @@ func TestAckDeletesInflightIndex(t *testing.T) {
 		t.Fatalf("ack status = %d, body = %s", ackRecorder.Code, ackRecorder.Body.String())
 	}
 
-	prefix := inflightPrefix()
-	iter, _ := Db.NewIter(&pebble.IterOptions{
-		LowerBound: prefix,
-		UpperBound: prefixUpperBound(prefix),
-	})
-	defer iter.Close()
-	for iter.SeekGE(prefix); iter.Valid(); iter.Next() {
-		t.Fatalf("expected no in-flight index keys, found %q", iter.Key())
+	// After ack the in-flight entry is gone and the message is no longer
+	// receivable or re-ackable.
+	ready, inflight, dead := runtimeQueueState(t, queueID)
+	if ready != 0 || inflight != 0 || dead != 0 {
+		t.Fatalf("after ack: ready=%d inflight=%d dead=%d, want all 0", ready, inflight, dead)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID, nil)
+	secondRecorder := httptest.NewRecorder()
+	receive(secondRecorder, secondReq)
+	if secondRecorder.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after ack, got %d: %s", secondRecorder.Code, secondRecorder.Body.String())
 	}
 }
 
@@ -621,52 +640,29 @@ func TestReapDeadLettersAfterMaxDeliveries(t *testing.T) {
 	}](t, recorder)
 
 	queueID := createResp.ID
-	messageID := publishTestMessage(t, queueID, []byte("poison"))
+	publishTestMessage(t, queueID, []byte("poison"))
 
 	_ = receiveTestMessage(t, queueID)
 
-	storedKey := storedMessageKey(t, queueID, messageID)
-	batch := Db.NewIndexedBatch()
-	val, closer, err := batch.Get(storedKey)
-	if err != nil {
-		t.Fatalf("get message: %v", err)
+	// Force the visibility timeout to elapse and reap from the runtime.
+	transitions := QueueManager.ReapExpired(context.Background(), time.Now().Add(31*time.Second))
+	if len(transitions) != 1 {
+		t.Fatalf("expected one reap transition, got %d", len(transitions))
 	}
-	var deadMsg Message
-	if err := json.Unmarshal(val, &deadMsg); err != nil {
-		closer.Close()
-		t.Fatalf("unmarshal message: %v", err)
-	}
-	closer.Close()
-	if err := deleteInflightIndex(batch, queueID, deadMsg); err != nil {
-		t.Fatalf("delete inflight index: %v", err)
-	}
-	deadMsg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
-	updated, err := json.Marshal(deadMsg)
-	if err != nil {
-		t.Fatalf("marshal message: %v", err)
-	}
-	if err := batch.Set(storedKey, updated, nil); err != nil {
-		t.Fatalf("set message: %v", err)
-	}
-	if err := setInflightIndex(batch, queueID, deadMsg, storedKey); err != nil {
-		t.Fatalf("set inflight index: %v", err)
-	}
-	if err := batch.Commit(pebble.NoSync); err != nil {
-		t.Fatalf("commit batch: %v", err)
-	}
-	batch.Close()
-
-	_, err = reapExpiredMessages(time.Now())
-	if err != nil {
-		t.Fatalf("reap expired messages: %v", err)
+	if transitions[0].QueueID != queueID || transitions[0].ToState != StateDead {
+		t.Fatalf("unexpected transition: %+v", transitions[0])
 	}
 
-	_, foundMsg, err := findMessageRecord(queueID, messageID)
-	if err != nil {
-		t.Fatalf("find message record: %v", err)
+	if _, _, dead := runtimeQueueState(t, queueID); dead != 1 {
+		t.Fatalf("expected 1 dead message after reap, got %d", dead)
 	}
-	if foundMsg.State != StateDead {
-		t.Fatalf("expected StateDead after max deliveries, got %s", foundMsg.State)
+
+	// Dead messages must not be delivered.
+	secondReq := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID, nil)
+	secondRecorder := httptest.NewRecorder()
+	receive(secondRecorder, secondReq)
+	if secondRecorder.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for dead-lettered queue, got %d: %s", secondRecorder.Code, secondRecorder.Body.String())
 	}
 }
 
@@ -683,46 +679,22 @@ func TestReaperUsesInflightIndexWithReadyBacklog(t *testing.T) {
 		publishTestMessage(t, queueID, []byte("ready-backlog"))
 	}
 
-	storedKey := storedMessageKey(t, queueID, messageID)
-	batch := Db.NewIndexedBatch()
-	val, closer, err := batch.Get(storedKey)
-	if err != nil {
-		t.Fatalf("get message: %v", err)
+	// The claimed message is in-flight; the 50 new messages are ready.
+	if ready, inflight, _ := runtimeQueueState(t, queueID); ready != 50 || inflight != 1 {
+		t.Fatalf("before reap: ready=%d inflight=%d, want 50,1", ready, inflight)
 	}
-	var expiredMsg Message
-	if err := json.Unmarshal(val, &expiredMsg); err != nil {
-		closer.Close()
-		t.Fatalf("unmarshal message: %v", err)
-	}
-	closer.Close()
-	if err := deleteInflightIndex(batch, queueID, expiredMsg); err != nil {
-		t.Fatalf("delete inflight index: %v", err)
-	}
-	expiredMsg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
-	updated, err := json.Marshal(expiredMsg)
-	if err != nil {
-		t.Fatalf("marshal message: %v", err)
-	}
-	if err := batch.Set(storedKey, updated, nil); err != nil {
-		t.Fatalf("set message: %v", err)
-	}
-	if err := setInflightIndex(batch, queueID, expiredMsg, storedKey); err != nil {
-		t.Fatalf("set inflight index: %v", err)
-	}
-	if err := batch.Commit(pebble.NoSync); err != nil {
-		t.Fatalf("commit batch: %v", err)
-	}
-	batch.Close()
 
-	transitions, err := reapExpiredMessages(time.Now())
-	if err != nil {
-		t.Fatalf("reap expired messages: %v", err)
-	}
+	transitions := QueueManager.ReapExpired(context.Background(), time.Now().Add(31*time.Second))
 	if len(transitions) != 1 {
-		t.Fatalf("expected one indexed reaper transition, got %d", len(transitions))
+		t.Fatalf("expected one reaper transition, got %d", len(transitions))
 	}
 	if transitions[0].QueueID != queueID || transitions[0].ToState != StateReady {
 		t.Fatalf("unexpected transition: %+v", transitions[0])
+	}
+
+	// Reaped message returns to ready tail; backlog is undisturbed.
+	if ready, inflight, dead := runtimeQueueState(t, queueID); ready != 51 || inflight != 0 || dead != 0 {
+		t.Fatalf("after reap: ready=%d inflight=%d dead=%d, want 51,0,0", ready, inflight, dead)
 	}
 }
 
@@ -745,6 +717,7 @@ func TestNackDeadLettersAfterMaxDeliveries(t *testing.T) {
 
 	queueID := createResp.ID
 	messageID := publishTestMessage(t, queueID, []byte("nack-poison"))
+	_ = messageID
 
 	resp := receiveTestMessage(t, queueID)
 
@@ -766,12 +739,16 @@ func TestNackDeadLettersAfterMaxDeliveries(t *testing.T) {
 		t.Fatalf("expected StateDead after nack with max deliveries, got %s", nackResp.State)
 	}
 
-	_, foundMsg, err := findMessageRecord(queueID, messageID)
-	if err != nil {
-		t.Fatalf("find message record: %v", err)
+	if _, _, dead := runtimeQueueState(t, queueID); dead != 1 {
+		t.Fatalf("expected 1 dead message after nack, got %d", dead)
 	}
-	if foundMsg.State != StateDead {
-		t.Fatalf("expected persisted StateDead, got %s", foundMsg.State)
+
+	// Dead messages must not be redelivered.
+	secondReq := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID, nil)
+	secondRecorder := httptest.NewRecorder()
+	receive(secondRecorder, secondReq)
+	if secondRecorder.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for dead-lettered queue, got %d: %s", secondRecorder.Code, secondRecorder.Body.String())
 	}
 }
 
@@ -798,12 +775,24 @@ func BenchmarkReceiveLatencyVsDepth(b *testing.B) {
 				b.Fatalf("open db: %v", err)
 			}
 			Db = db
+			Queues = nil
+			DeadLetterQueue = nil
 			metricsStore = sync.Map{}
+			messageKeyCache = sync.Map{}
 			receiveChannel = make(chan struct{}, 1)
 			queueReadyChans = map[string]chan struct{}{}
+			deliveryRecordSeq.Store(0)
+			qm, wal, err := initQueueManagerFromEnv(context.Background(), db)
+			if err != nil {
+				b.Fatalf("init queue manager: %v", err)
+			}
+			QueueManager = qm
+			WAL = wal
 			b.Cleanup(func() {
 				db.Close()
 				Db = nil
+				QueueManager = nil
+				WAL = nil
 			})
 
 			queueID := createBenchQueue(b, "bench-queue")
@@ -990,10 +979,21 @@ func setupDepthBenchmarkDB(b *testing.B) string {
 	receiveChannel = make(chan struct{}, 1)
 	queueReadyChans = map[string]chan struct{}{}
 	metricsStore = sync.Map{}
+	messageKeyCache = sync.Map{}
+	deliveryRecordSeq.Store(0)
+
+	qm, wal, err := initQueueManagerFromEnv(context.Background(), db)
+	if err != nil {
+		b.Fatalf("init queue manager: %v", err)
+	}
+	QueueManager = qm
+	WAL = wal
 
 	b.Cleanup(func() {
 		_ = db.Close()
 		Db = nil
+		QueueManager = nil
+		WAL = nil
 	})
 
 	return createBenchQueue(b, "depth-bench-queue")
@@ -1291,16 +1291,21 @@ func TestBatchAckMultipleMessages(t *testing.T) {
 		}
 	}
 
-	// Verify all messages are deleted
-	for _, msgID := range []string{msg1ID, msg2ID, msg3ID} {
-		key, _, err := findMessageRecord(queueID, msgID)
-		if err == nil {
-			t.Fatalf("expected message %s to be deleted, found at %x", msgID, key)
-		}
-		if err != pebble.ErrNotFound {
-			t.Fatalf("unexpected error finding message %s: %v", msgID, err)
-		}
+	// Verify all messages are gone from the runtime.
+	ready, inflight, dead := runtimeQueueState(t, queueID)
+	if ready != 0 || inflight != 0 || dead != 0 {
+		t.Fatalf("after batch ack: ready=%d inflight=%d dead=%d, want all 0", ready, inflight, dead)
 	}
+
+	emptyReq := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID, nil)
+	emptyRec := httptest.NewRecorder()
+	receive(emptyRec, emptyReq)
+	if emptyRec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after batch ack, got %d: %s", emptyRec.Code, emptyRec.Body.String())
+	}
+	_ = msg1ID
+	_ = msg2ID
+	_ = msg3ID
 }
 
 func TestBatchAckReportsPartialErrors(t *testing.T) {
@@ -1309,7 +1314,7 @@ func TestBatchAckReportsPartialErrors(t *testing.T) {
 	queueID := createTestQueue(t, "batch-ack-err-queue")
 
 	_ = publishTestMessage(t, queueID, []byte("one"))
-	msg2ID := publishTestMessage(t, queueID, []byte("two"))
+	_ = publishTestMessage(t, queueID, []byte("two"))
 
 	batchResp := func() testBatchReceiveResponse {
 		req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID+"&max=10", nil)
@@ -1351,18 +1356,23 @@ func TestBatchAckReportsPartialErrors(t *testing.T) {
 		t.Fatalf("ack[1] expected error, got %s", r1.Status)
 	}
 
-	// msg1 should be deleted, msg2 should still exist
-	var msg2Exists bool
-	_, _, err := findMessageRecord(queueID, msg2ID)
-	if err == pebble.ErrNotFound {
-		msg2Exists = false
-	} else if err != nil {
-		t.Fatalf("check msg2: %v", err)
-	} else {
-		msg2Exists = true
+	// msg2 (wrong token) must still be in-flight: re-acking with the correct
+	// token succeeds, proving it was not deleted by the failed batch ack.
+	reAckBody, _ := json.Marshal(BatchAckRequest{
+		QueueId: queueID,
+		Acks: []AckEntry{
+			{ReceiptHandle: batchResp.Messages[1].ReceiptHandle, DeliveryToken: batchResp.Messages[1].DeliveryToken},
+		},
+	})
+	reAckReq := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(reAckBody))
+	reAckRecorder := httptest.NewRecorder()
+	ack(reAckRecorder, reAckReq)
+	if reAckRecorder.Code != http.StatusAccepted {
+		t.Fatalf("re-ack of msg2 status = %d, body = %s", reAckRecorder.Code, reAckRecorder.Body.String())
 	}
-	if !msg2Exists {
-		t.Fatal("msg2 should not have been deleted")
+	reAckResp := decodeResponse[batchAckResponse](t, reAckRecorder)
+	if reAckResp.Results[0].Status != "ok" {
+		t.Fatalf("re-ack of msg2 expected ok, got %s: %s", reAckResp.Results[0].Status, reAckResp.Results[0].Error)
 	}
 }
 
@@ -1436,6 +1446,235 @@ func TestBatchReceiveLongPollWithWait(t *testing.T) {
 	// FIFO: first published should be first received
 	if string(resp.Messages[0].Body) != "batch-0" {
 		t.Fatalf("first message body = %q, want batch-0", string(resp.Messages[0].Body))
+	}
+}
+
+// ============================================================================
+// Phase 2.4: create/publish handler runtime+WAL integration
+// ============================================================================
+
+func setupTestDBWithFakeWAL(t *testing.T) *fakeWAL {
+	t.Helper()
+
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+
+	Db = db
+	Queues = nil
+	DeadLetterQueue = nil
+	receiveChannel = make(chan struct{}, 1)
+	queueReadyChans = map[string]chan struct{}{}
+	metricsStore = sync.Map{}
+	messageKeyCache = sync.Map{}
+	deliveryRecordSeq.Store(0)
+
+	wal := &fakeWAL{}
+	QueueManager = newQueueManager(wal)
+
+	t.Cleanup(func() {
+		_ = db.Close()
+		Db = nil
+		QueueManager = nil
+	})
+
+	return wal
+}
+
+func collectReadySeqs(q *queueRuntime) []uint64 {
+	var seqs []uint64
+	for e := q.ready.Front(); e != nil; e = e.Next() {
+		seqs = append(seqs, e.Value.(*messageRecord).Seq)
+	}
+	return seqs
+}
+
+func TestPublishHandlerWALFailureReturns500AndRollsBack(t *testing.T) {
+	wal := setupTestDBWithFakeWAL(t)
+	queueID := createTestQueue(t, "wal-fail-handler")
+
+	publishTestMessage(t, queueID, []byte("ok"))
+
+	wal.mu.Lock()
+	beforeFail := len(wal.entries)
+	wal.fail = true
+	wal.mu.Unlock()
+
+	body, _ := json.Marshal(PublishRequest{QueueId: queueID, Message: Message{Body: []byte("fail")}})
+	req := httptest.NewRequest(http.MethodPost, "/publish", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	publish(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on WAL failure, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	wal.mu.Lock()
+	afterFail := len(wal.entries)
+	wal.fail = false
+	wal.mu.Unlock()
+	if afterFail != beforeFail {
+		t.Fatalf("WAL entries changed on failed publish: %d -> %d", beforeFail, afterFail)
+	}
+
+	ready, inflight, dead := runtimeQueueState(t, queueID)
+	if ready != 1 || inflight != 0 || dead != 0 {
+		t.Fatalf("after failed publish: ready=%d inflight=%d dead=%d, want 1,0,0", ready, inflight, dead)
+	}
+
+	q, _ := QueueManager.getQueue(queueID)
+	q.mu.Lock()
+	nextSeq := q.nextSeq
+	q.mu.Unlock()
+	if nextSeq != 1 {
+		t.Fatalf("nextSeq = %d after rolled-back publish, want 1", nextSeq)
+	}
+}
+
+func TestPublishHandlerMemoryLimitReturns429(t *testing.T) {
+	wal := setupTestDBWithFakeWAL(t)
+	queueID := createTestQueue(t, "mem-limit-handler")
+
+	q, err := QueueManager.getQueue(queueID)
+	if err != nil {
+		t.Fatalf("get queue: %v", err)
+	}
+	q.mu.Lock()
+	q.maxMessages = 1
+	q.mu.Unlock()
+
+	publishTestMessage(t, queueID, []byte("first"))
+
+	body, _ := json.Marshal(PublishRequest{QueueId: queueID, Message: Message{Body: []byte("second")}})
+	req := httptest.NewRequest(http.MethodPost, "/publish", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	publish(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 on memory limit, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if ready, _, _ := runtimeQueueState(t, queueID); ready != 1 {
+		t.Fatalf("ready = %d, want 1 (rejected publish must not mutate memory)", ready)
+	}
+
+	wal.mu.Lock()
+	n := len(wal.entries)
+	wal.mu.Unlock()
+	if n != 2 {
+		t.Fatalf("WAL entries = %d, want 2 (create + one publish; rejected publish appends nothing)", n)
+	}
+}
+
+func TestPerQueueSequenceIndependence(t *testing.T) {
+	setupTestDB(t)
+	queueA := createTestQueue(t, "seq-a")
+	queueB := createTestQueue(t, "seq-b")
+
+	const n = 10
+	for i := 0; i < n; i++ {
+		publishTestMessage(t, queueA, []byte("a"))
+		publishTestMessage(t, queueB, []byte("b"))
+	}
+
+	qA, _ := QueueManager.getQueue(queueA)
+	qB, _ := QueueManager.getQueue(queueB)
+	qA.mu.Lock()
+	seqsA := collectReadySeqs(qA)
+	qA.mu.Unlock()
+	qB.mu.Lock()
+	seqsB := collectReadySeqs(qB)
+	qB.mu.Unlock()
+
+	if len(seqsA) != n || len(seqsB) != n {
+		t.Fatalf("seq counts = %d, %d, want %d each", len(seqsA), len(seqsB), n)
+	}
+	for i, s := range seqsA {
+		if s != uint64(i) {
+			t.Fatalf("seqA[%d] = %d, want %d", i, s, i)
+		}
+	}
+	for i, s := range seqsB {
+		if s != uint64(i) {
+			t.Fatalf("seqB[%d] = %d, want %d", i, s, i)
+		}
+	}
+}
+
+func TestCreatePublishAPICompatibility(t *testing.T) {
+	setupTestDB(t)
+
+	// create bad JSON -> 400
+	badCreate := httptest.NewRequest(http.MethodPost, "/create", bytes.NewReader([]byte("{bad")))
+	badCreateRec := httptest.NewRecorder()
+	create(badCreateRec, badCreate)
+	if badCreateRec.Code != http.StatusBadRequest {
+		t.Fatalf("create bad json status = %d, want 400", badCreateRec.Code)
+	}
+
+	// create happy path -> 202 + {id, state: ready}
+	queueID := createTestQueue(t, "compat-queue")
+
+	// single publish -> 202 + {id, state: ready}
+	body, _ := json.Marshal(PublishRequest{QueueId: queueID, Message: Message{Body: []byte("x")}})
+	req := httptest.NewRequest(http.MethodPost, "/publish", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	publish(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("publish status = %d, want 202", rec.Code)
+	}
+	var pr struct {
+		ID    string       `json:"id"`
+		State MessageState `json:"state"`
+	}
+	json.NewDecoder(rec.Body).Decode(&pr)
+	if pr.ID == "" {
+		t.Fatal("publish returned empty id")
+	}
+	if pr.State != StateReady {
+		t.Fatalf("publish state = %s, want ready", pr.State)
+	}
+
+	// publish-batch -> 202 + {ids:[...]}
+	batchBody, _ := json.Marshal(BatchPublishRequest{
+		QueueId:  queueID,
+		Messages: []Message{{Body: []byte("y")}, {Body: []byte("z")}},
+	})
+	breq := httptest.NewRequest(http.MethodPost, "/publish-batch", bytes.NewReader(batchBody))
+	brec := httptest.NewRecorder()
+	publishBatch(brec, breq)
+	if brec.Code != http.StatusAccepted {
+		t.Fatalf("publish-batch status = %d, want 202", brec.Code)
+	}
+	var br BatchPublishResponse
+	json.NewDecoder(brec.Body).Decode(&br)
+	if len(br.IDs) != 2 {
+		t.Fatalf("batch ids = %d, want 2", len(br.IDs))
+	}
+
+	// publish to missing queue -> 404
+	missBody, _ := json.Marshal(PublishRequest{QueueId: "nope", Message: Message{Body: []byte("x")}})
+	mreq := httptest.NewRequest(http.MethodPost, "/publish", bytes.NewReader(missBody))
+	mrec := httptest.NewRecorder()
+	publish(mrec, mreq)
+	if mrec.Code != http.StatusNotFound {
+		t.Fatalf("missing queue publish status = %d, want 404", mrec.Code)
+	}
+
+	// publish bad JSON -> 400
+	badReq := httptest.NewRequest(http.MethodPost, "/publish", bytes.NewReader([]byte("{bad")))
+	badRec := httptest.NewRecorder()
+	publish(badRec, badReq)
+	if badRec.Code != http.StatusBadRequest {
+		t.Fatalf("bad json publish status = %d, want 400", badRec.Code)
+	}
+
+	// publish-batch empty messages -> 400
+	emptyBatch, _ := json.Marshal(BatchPublishRequest{QueueId: queueID, Messages: nil})
+	emptyReq := httptest.NewRequest(http.MethodPost, "/publish-batch", bytes.NewReader(emptyBatch))
+	emptyRec := httptest.NewRecorder()
+	publishBatch(emptyRec, emptyReq)
+	if emptyRec.Code != http.StatusBadRequest {
+		t.Fatalf("empty batch status = %d, want 400", emptyRec.Code)
 	}
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"math"
 	"net/http"
@@ -135,16 +136,14 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, closer, err := Db.Get([]byte(id))
-	if err != nil {
-		if err == pebble.ErrNotFound {
+	if _, err := QueueManager.getQueue(id); err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
 			http.Error(w, "Queue Not Found for id: "+id, http.StatusNotFound)
 			return
 		}
 		http.Error(w, "Error checking queue: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	closer.Close()
 
 	m := getOrCreateMetrics(id)
 	if err := reconcileMetricsFromDBIfStale(id, m, time.Now()); err != nil {

--- a/reaper.go
+++ b/reaper.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -142,24 +142,15 @@ func reaper() {
 		defer ticker.Stop()
 
 		for range ticker.C {
-			transitions, err := reapExpiredMessages(time.Now())
-			if err != nil {
-				log.Println("reaper:", err)
-				continue
-			}
+			transitions := QueueManager.ReapExpired(context.Background(), time.Now())
 
 			signaled := map[string]struct{}{}
 			for _, t := range transitions {
-				m := getOrCreateMetrics(t.QueueID)
-				m.inFlightCount.Add(-1)
 				if t.ToState == StateReady {
-					m.readyCount.Add(1)
 					if _, ok := signaled[t.QueueID]; !ok {
 						signalQueueReady(t.QueueID)
 						signaled[t.QueueID] = struct{}{}
 					}
-				} else if t.ToState == StateDead {
-					m.deadCount.Add(1)
 				}
 			}
 

--- a/runtime.go
+++ b/runtime.go
@@ -6,7 +6,6 @@ import (
 	"container/list"
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -135,7 +134,7 @@ func (qm *queueManager) getQueue(queueID string) (*queueRuntime, error) {
 	q, ok := qm.queues[queueID]
 	qm.mu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("queue %q not found", queueID)
+		return nil, fmt.Errorf("%w: %q", ErrQueueNotFound, queueID)
 	}
 	return q, nil
 }
@@ -182,14 +181,14 @@ func (qm *queueManager) PublishBatch(ctx context.Context, queueID string, bodies
 
 	// Enforce memory limits.
 	if q.maxMessages > 0 && int64(len(q.messages)+n) > q.maxMessages {
-		return nil, errors.New("queue message limit exceeded")
+		return nil, ErrMessageLimitExceeded
 	}
 	var totalBytes int64
 	for _, b := range bodies {
 		totalBytes += int64(len(b))
 	}
 	if q.maxBytes > 0 && q.bytesInMem+totalBytes > q.maxBytes {
-		return nil, errors.New("queue byte limit exceeded")
+		return nil, ErrByteLimitExceeded
 	}
 
 	// Allocate seq range.
@@ -363,6 +362,7 @@ func (msg *messageRecord) toClaimedMessage() claimedMessage {
 }
 
 type runtimeAckResult struct {
+	MessageID     string
 	ReceiptHandle string
 	Status        string // "ok" or "error"
 	Error         string
@@ -410,6 +410,7 @@ func (qm *queueManager) AckBatch(ctx context.Context, queueID string, acks []Ack
 		seen[entry.ReceiptHandle] = true
 		valid = append(valid, dr)
 		results[i].Status = "ok"
+		results[i].MessageID = dr.MessageID
 	}
 
 	if len(valid) == 0 {
@@ -476,7 +477,7 @@ func (qm *queueManager) Nack(ctx context.Context, queueID, receiptHandle, delive
 
 	msg, ok := q.messages[dr.MessageID]
 	if !ok {
-		return "", errors.New("message not found")
+		return "", ErrMessageNotFound
 	}
 
 	// Remove from inflight and deadlines.
@@ -532,6 +533,7 @@ func (qm *queueManager) Nack(ctx context.Context, queueID, receiptHandle, delive
 	}
 
 	q.metrics.inFlightCount.Add(-1)
+	q.metrics.totalNacked.Add(1)
 	if targetState == StateReady {
 		q.metrics.readyCount.Add(1)
 		q.signalReady()


### PR DESCRIPTION
Closes #29. Parent: #21. Depends on Phase 2.1 (#26), 2.2 (#27), 2.3 (#28/PR #39, merged).

## Scope

Issue #29 scoped only create + publish handlers. Once publish stops writing the legacy Pebble `messageKey`/`readyKey` layout (the issue explicitly forbids dual-write), the legacy `receive`/`ack`/`nack` handlers can no longer see newly published messages and ~20 existing pipeline tests break. Parent issue #21 requires all existing tests to pass. To resolve this within the #29 PR boundary, this PR switches **all** handlers plus the reaper to `queueRuntime`+WAL. This absorbs #30's handler work; #30 then becomes reaper/metrics cleanup.

## Work

- `create` / `getQueue` → `QueueManager.CreateQueue` + runtime config lookup.
- `publish` / `publish-batch` → `QueueManager.PublishBatch` with error mapping:
  - queue-missing → 404
  - `ErrMessageLimitExceeded` / `ErrByteLimitExceeded` → **429** (no WAL append, no memory mutation)
  - WAL append failure → 500 (runtime rolls back seq allocation; no message becomes visible)
- `receive` / `receive-batch` → `QueueManager.ClaimBatch`; long-poll keeps the broadcast `queueReadyChan` so competing-consumer wake semantics are preserved.
- `ack` / `ack-batch` / `nack` → `QueueManager.AckBatch` / `Nack` with status mapping (400 not-found handle, 409 token mismatch, 404 missing queue/message, 500 WAL).
- Reaper goroutine → `QueueManager.ReapExpired`; signals `queueReadyChan` only on ready transitions.
- `metricsHandler` queue-existence check → runtime lookup (reconcile scan still in place — removal is #31).

### Runtime additions
- Sentinel errors: `ErrQueueNotFound`, `ErrMessageLimitExceeded`, `ErrByteLimitExceeded`, `ErrMessageNotFound` — for clean handler error mapping.
- Live `Nack` now increments `totalNacked` (parity with recovery replay and legacy handler).
- `runtimeAckResult` carries `MessageID` so batch ack responses can report it.

### Test infrastructure
- `setupTestDB` and the bench DB setups initialize `QueueManager` + `WAL` via `initQueueManagerFromEnv` and nil them on cleanup.

## Tests

- Rewrote 7 Pebble-peeking tests to assert runtime-observable behavior instead of scanning Pebble keys: `TestPublishReceiveAck`, `TestAckDeletesInflightIndex`, `TestReapDeadLettersAfterMaxDeliveries`, `TestReaperUsesInflightIndexWithReadyBacklog`, `TestNackDeadLettersAfterMaxDeliveries`, `TestBatchAckReportsPartialErrors`, `TestBatchAckMultipleMessages`.
- Added 4 new tests per the issue's pre-commit validation list:
  - `TestPublishHandlerWALFailureReturns500AndRollsBack` — WAL failure returns 500, no WAL entry, no memory mutation, seq rolled back.
  - `TestPublishHandlerMemoryLimitReturns429` — memory limit returns 429, no WAL entry, memory unchanged.
  - `TestPerQueueSequenceIndependence` — two queues get independent 0..N-1 seq ranges under concurrent publish.
  - `TestCreatePublishAPICompatibility` — create/publish/publish-batch status codes and response shapes preserved.

## Out of scope (deferred)

- Legacy Pebble hot-path functions (`claimReadyMessages`, `reapExpiredMessages`, `nextMessageSequence`, `messageByReceiptHandle`, `findMessageRecord`, key builders, `claimMu`, `seqMu`) are now dead code in the live path but retained so benchmarks compile. Removal is #35 (Phase 2.10).
- `Benchmark*` functions still call legacy `claimReadyMessages` / `reapExpiredMessages`; they will fail under `-bench` since publish now writes to runtime, not Pebble. Benchmark rewrite is #34 (Phase 2.9). They compile and do not affect `go test ./...`.
- `/metrics` still runs `reconcileMetricsFromDB` over the now-empty Pebble keyspace (harmless, no-op scan). Moving metrics fully in-memory is #31.

## Acceptance criteria (#29)

- [x] Public API behavior for create/publish/publish-batch remains compatible with existing tests.
- [x] Publish sequence is allocated per queue via `queueRuntime.nextSeq`, not through global `seqMu`.
- [x] If WAL append fails, publish returns 500 and no message becomes visible in memory (seq rolled back).
- [x] Queue-ready signaling still wakes long-poll receivers.
- [x] Old Pebble message-key writes are not used for newly published messages in this path.
- [x] HTTP 429 returned without WAL append or memory mutation when limits would be exceeded.

## Validation

```
go build ./...        # clean
go test ./...         # ok  kueue, ok kueue/cmd/bench
go test -race ./...   # ok  kueue, ok kueue/cmd/bench
go vet ./...          # clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses with more specific HTTP status codes for various queue operations, including queue-not-found (404), rate-limit scenarios (429), and validation failures.

* **Improvements**
  * Enhanced message state management and queue readiness signaling for more reliable message processing, delivery, and state consistency across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->