### PR TITLE
Phase 2.5: Validate receive/ack/nack runtime path, fix benchmarks, remove dead code

### DIFF
--- a/handlers_receive.go
+++ b/handlers_receive.go
@@ -4,18 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
-
-	"github.com/cockroachdb/pebble/v2"
-	"github.com/google/uuid"
 )
-
-var claimMu sync.Mutex
 
 func claimWithWait(ctx context.Context, id string, max int, wait bool) ([]claimedMessage, error) {
 	msgs, err := QueueManager.ClaimBatch(ctx, id, max)
@@ -204,121 +197,4 @@ func receiveBatch(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(resp)
-}
-
-// Legacy Pebble-based claim path. Retained for benchmark compatibility while
-// the live handlers route through queueManager.ClaimBatch. Pending removal in
-// Phase 2.10.
-
-func claimNextReadyMessage(queueId string) (*claimedMessage, error) {
-	msgs, err := claimReadyMessages(queueId, 1)
-	if err != nil {
-		return nil, err
-	}
-	return &msgs[0], nil
-}
-
-func claimReadyMessages(queueId string, max int) ([]claimedMessage, error) {
-	claimMu.Lock()
-	defer claimMu.Unlock()
-	var claimed []claimedMessage
-	batch := Db.NewIndexedBatch()
-	defer batch.Close()
-
-	prefix := readyPrefix(queueId)
-	iter, _ := batch.NewIter(&pebble.IterOptions{
-		LowerBound: prefix,
-		UpperBound: prefixUpperBound(prefix),
-	})
-	defer iter.Close()
-
-	for iter.SeekGE(prefix); iter.Valid() && len(claimed) < max; iter.Next() {
-		rKey := append([]byte(nil), iter.Key()...)
-		_, msgID, err := readyPartsFromKey(rKey, prefix)
-		if err != nil {
-			return nil, fmt.Errorf("parse ready key: %w", err)
-		}
-
-		val, err := iter.ValueAndErr()
-		if err != nil {
-			return nil, fmt.Errorf("read ready value: %w", err)
-		}
-		msgKey, err := parseReadyValue(val)
-		if err != nil {
-			return nil, fmt.Errorf("parse ready value: %w", err)
-		}
-
-		msgVal, closer, err := batch.Get(msgKey)
-		if err != nil {
-			if err == pebble.ErrNotFound {
-				readySeq, _, parseErr := readyPartsFromKey(rKey, prefix)
-				if parseErr != nil {
-					return nil, fmt.Errorf("parse ready key fallback: %w", parseErr)
-				}
-				msgKey = messageKeyBytes(queueId, readySeq, msgID)
-				msgVal, closer, err = batch.Get(msgKey)
-				if err == pebble.ErrNotFound {
-					if delErr := batch.Delete(rKey, nil); delErr != nil {
-						return nil, fmt.Errorf("delete stale ready pointer %x: %w", rKey, delErr)
-					}
-					continue
-				}
-				if err != nil {
-					return nil, fmt.Errorf("get message for ready key: %w", err)
-				}
-			} else {
-				return nil, fmt.Errorf("get message for ready key: %w", err)
-			}
-		}
-
-		var msg Message
-		if err := json.Unmarshal(msgVal, &msg); err != nil {
-			closer.Close()
-			return nil, fmt.Errorf("unmarshal message: %w", err)
-		}
-		closer.Close()
-
-		if msg.State != StateReady {
-			batch.Delete(rKey, nil)
-			continue
-		}
-
-		if err := batch.Delete(rKey, nil); err != nil {
-			return nil, fmt.Errorf("delete ready key: %w", err)
-		}
-
-		msg.State = StateInFlight
-		msg.VisibilityDeadline = time.Now().Add(30 * time.Second)
-		msg.DeliveryCount++
-		msg.DeliveryAttemptID = uuid.NewString()
-
-		updated, err := json.Marshal(msg)
-		if err != nil {
-			return nil, fmt.Errorf("marshal claimed message: %w", err)
-		}
-		if err := batch.Set(msgKey, updated, nil); err != nil {
-			return nil, fmt.Errorf("set claimed message: %w", err)
-		}
-		if err := setInflightIndex(batch, queueId, msg, msgKey); err != nil {
-			return nil, fmt.Errorf("set in-flight index: %w", err)
-		}
-
-		receiptHandle := receiptHandleForMessageKey(msgKey)
-		cacheMessageKey(receiptHandle, msgKey)
-		claimed = append(claimed, claimedMessage{
-			Message:       msg,
-			ReceiptHandle: receiptHandle,
-		})
-	}
-
-	if len(claimed) == 0 {
-		iter.Close()
-		batch.Close()
-		return nil, ErrNoReadyMessages
-	}
-
-	if err := batch.Commit(pebble.NoSync); err != nil {
-		return nil, fmt.Errorf("commit claim batch: %w", err)
-	}
-	return claimed, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -418,85 +418,6 @@ func TestReceiveLongPollIgnoresOtherQueuePublishes(t *testing.T) {
 	}
 }
 
-func TestReapExpiredMessagesResetsPersistedInFlightMessage(t *testing.T) {
-	t.Skip("TODO: fix nested batch write issue in nextMessageSequence")
-	setupTestDB(t)
-
-	queueID := createTestQueue(t, "reaper-queue")
-	messageID := publishTestMessage(t, queueID, []byte("expired"))
-
-	firstResp := receiveTestMessage(t, queueID)
-	firstToken := firstResp.DeliveryToken
-	firstReceiptHandle := firstResp.ReceiptHandle
-
-	storedKey := storedMessageKey(t, queueID, messageID)
-	batch := Db.NewIndexedBatch()
-	defer batch.Close()
-	val, closer, err := batch.Get(storedKey)
-	if err != nil {
-		t.Fatalf("get message: %v", err)
-	}
-	var msg Message
-	if err := json.Unmarshal(val, &msg); err != nil {
-		closer.Close()
-		t.Fatalf("unmarshal message: %v", err)
-	}
-	closer.Close()
-
-	if err := deleteInflightIndex(batch, queueID, msg); err != nil {
-		t.Fatalf("delete inflight index: %v", err)
-	}
-	msg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
-
-	updated, err := json.Marshal(msg)
-	if err != nil {
-		t.Fatalf("marshal message: %v", err)
-	}
-
-	if err := batch.Set(storedKey, updated, nil); err != nil {
-		t.Fatalf("set message: %v", err)
-	}
-	if err := setInflightIndex(batch, queueID, msg, storedKey); err != nil {
-		t.Fatalf("set inflight index: %v", err)
-	}
-	if err := batch.Commit(pebble.NoSync); err != nil {
-		t.Fatalf("commit batch: %v", err)
-	}
-
-	time.Sleep(200 * time.Millisecond)
-	recoveredTransitions, err := reapExpiredMessages(time.Now())
-	if err != nil {
-		t.Fatalf("reap expired messages: %v", err)
-	}
-	if len(recoveredTransitions) != 1 || recoveredTransitions[0].QueueID != queueID {
-		t.Fatal("expected reapExpiredMessages to recover the expired message")
-	}
-
-	secondResp := receiveTestMessage(t, queueID)
-
-	if secondResp.ID != messageID {
-		t.Fatalf("expected same message id after reap, got %s", secondResp.ID)
-	}
-	if string(secondResp.Body) != "expired" {
-		t.Fatalf("expected body expired, got %q", string(secondResp.Body))
-	}
-	if secondResp.State != StateInFlight {
-		t.Fatalf("expected in-flight state after re-receive, got %s", secondResp.State)
-	}
-
-	// Stale delivery token should be rejected
-	ackBody, err := json.Marshal(AckRequest{QueueId: queueID, ReceiptHandle: firstReceiptHandle, DeliveryToken: firstToken})
-	if err != nil {
-		t.Fatalf("marshal ack request: %v", err)
-	}
-	ackReq := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(ackBody))
-	ackRecorder := httptest.NewRecorder()
-	ack(ackRecorder, ackReq)
-	if ackRecorder.Code != http.StatusConflict {
-		t.Fatalf("expected 409 for stale delivery token, got %d: %s", ackRecorder.Code, ackRecorder.Body.String())
-	}
-}
-
 func TestAckRejectsWrongDeliveryToken(t *testing.T) {
 	setupTestDB(t)
 
@@ -1010,7 +931,7 @@ func BenchmarkBatchReceiveOnly(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				msgs, err := claimReadyMessages(queueID, batchSize)
+				msgs, err := QueueManager.ClaimBatch(context.Background(), queueID, batchSize)
 				if err != nil {
 					b.Fatalf("claim batch: %v", err)
 				}
@@ -1033,7 +954,7 @@ func BenchmarkBatchAckOnly(b *testing.B) {
 
 			batches := make([][]claimedMessage, 0, b.N)
 			for i := 0; i < b.N; i++ {
-				msgs, err := claimReadyMessages(queueID, batchSize)
+				msgs, err := QueueManager.ClaimBatch(context.Background(), queueID, batchSize)
 				if err != nil {
 					b.Fatalf("claim batch: %v", err)
 				}
@@ -1059,7 +980,7 @@ func BenchmarkBatchReceiveAndAck(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				msgs, err := claimReadyMessages(queueID, batchSize)
+				msgs, err := QueueManager.ClaimBatch(context.Background(), queueID, batchSize)
 				if err != nil {
 					b.Fatalf("claim batch: %v", err)
 				}
@@ -1079,51 +1000,14 @@ func BenchmarkReaperDueInflightIndex(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				publishBenchMessage(b, queueID, []byte("expired"))
-				resp := receiveBenchMessage(b, queueID)
-				key, err := messageKeyFromReceiptHandle(queueID, resp.ReceiptHandle)
-				if err != nil {
-					b.Fatalf("decode receipt handle: %v", err)
-				}
-				err = func() error {
-					batch := Db.NewIndexedBatch()
-					defer batch.Close()
-					val, closer, err := batch.Get(key)
-					if err != nil {
-						return err
-					}
-					var benchMsg Message
-					if err := json.Unmarshal(val, &benchMsg); err != nil {
-						closer.Close()
-						return err
-					}
-					closer.Close()
-					if err := deleteInflightIndex(batch, queueID, benchMsg); err != nil {
-						return err
-					}
-					benchMsg.VisibilityDeadline = time.Now().Add(-1 * time.Second)
-					updated, err := json.Marshal(benchMsg)
-					if err != nil {
-						return err
-					}
-					if err := batch.Set(key, updated, nil); err != nil {
-						return err
-					}
-					if err := setInflightIndex(batch, queueID, benchMsg, key); err != nil {
-						return err
-					}
-					return batch.Commit(pebble.NoSync)
-				}()
-				if err != nil {
-					b.Fatalf("prepare expired message: %v", err)
+				if _, err := QueueManager.ClaimBatch(context.Background(), queueID, 1); err != nil {
+					b.Fatalf("claim for reap: %v", err)
 				}
 			}
 
 			b.ResetTimer()
-			transitions, err := reapExpiredMessages(time.Now())
+			transitions := QueueManager.ReapExpired(context.Background(), time.Now().Add(31*time.Second))
 			b.StopTimer()
-			if err != nil {
-				b.Fatalf("reap expired messages: %v", err)
-			}
 			if len(transitions) != b.N {
 				b.Fatalf("reaped %d messages, want %d", len(transitions), b.N)
 			}
@@ -1677,6 +1561,182 @@ func TestCreatePublishAPICompatibility(t *testing.T) {
 	publishBatch(emptyRec, emptyReq)
 	if emptyRec.Code != http.StatusBadRequest {
 		t.Fatalf("empty batch status = %d, want 400", emptyRec.Code)
+	}
+}
+
+// ============================================================================
+// Phase 2.5: receive/ack/nack handler-level validation
+// ============================================================================
+
+func TestCompetingConsumersNoDuplicateDelivery(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "competing-consumers")
+	const totalMsgs = 100
+	const consumers = 10
+
+	for i := 0; i < totalMsgs; i++ {
+		publishTestMessage(t, queueID, []byte(fmt.Sprintf("msg-%d", i)))
+	}
+
+	type consumerResult struct {
+		ids []string
+		err error
+	}
+
+	var mu sync.Mutex
+	results := make([]consumerResult, consumers)
+	var wg sync.WaitGroup
+	wg.Add(consumers)
+
+	for c := 0; c < consumers; c++ {
+		go func(consumerIdx int) {
+			defer wg.Done()
+			var ids []string
+			for {
+				req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID, nil)
+				rec := httptest.NewRecorder()
+				receive(rec, req)
+				if rec.Code == http.StatusNotFound {
+					break
+				}
+				if rec.Code != http.StatusAccepted {
+					results[consumerIdx].err = fmt.Errorf("consumer %d: receive status = %d, body = %s", consumerIdx, rec.Code, rec.Body.String())
+					return
+				}
+				resp := decodeResponse[receiveResponse](t, rec)
+				ids = append(ids, resp.ID)
+			}
+			mu.Lock()
+			results[consumerIdx].ids = ids
+			mu.Unlock()
+		}(c)
+	}
+
+	wg.Wait()
+
+	for i, r := range results {
+		if r.err != nil {
+			t.Fatalf("consumer %d failed: %v", i, r.err)
+		}
+	}
+
+	allIDs := make(map[string]int)
+	totalConsumed := 0
+	for _, r := range results {
+		for _, id := range r.ids {
+			if allIDs[id] > 0 {
+				t.Fatalf("duplicate delivery: message %s delivered to multiple consumers", id)
+			}
+			allIDs[id]++
+			totalConsumed++
+		}
+	}
+
+	if totalConsumed != totalMsgs {
+		t.Fatalf("total consumed = %d, want %d", totalConsumed, totalMsgs)
+	}
+
+	minCount, maxCount := totalMsgs, 0
+	for _, r := range results {
+		count := len(r.ids)
+		if count < minCount {
+			minCount = count
+		}
+		if count > maxCount {
+			maxCount = count
+		}
+	}
+	if minCount == 0 {
+		t.Fatalf("a consumer received 0 messages: distribution min=%d max=%d", minCount, maxCount)
+	}
+}
+
+func TestHandlerStaleAckTokenAfterRedeliveryReturns409(t *testing.T) {
+	setupTestDB(t)
+
+	queueID := createTestQueue(t, "stale-token-handler")
+
+	publishTestMessage(t, queueID, []byte("poison"))
+
+	firstResp := receiveTestMessage(t, queueID)
+	oldToken := firstResp.DeliveryToken
+	receiptHandle := firstResp.ReceiptHandle
+
+	nackBody, _ := json.Marshal(AckRequest{
+		QueueId:       queueID,
+		ReceiptHandle: receiptHandle,
+		DeliveryToken: oldToken,
+	})
+	nackReq := httptest.NewRequest(http.MethodPost, "/nack", bytes.NewReader(nackBody))
+	nackRec := httptest.NewRecorder()
+	nack(nackRec, nackReq)
+	if nackRec.Code != http.StatusAccepted {
+		t.Fatalf("nack status = %d, want 202, body = %s", nackRec.Code, nackRec.Body.String())
+	}
+
+	secondResp := receiveTestMessage(t, queueID)
+	if secondResp.DeliveryToken == oldToken {
+		t.Fatal("expected new delivery token after redelivery")
+	}
+	if secondResp.ReceiptHandle != receiptHandle {
+		t.Fatalf("receipt handle changed: got %q, want %q (immutable across redeliveries)", secondResp.ReceiptHandle, receiptHandle)
+	}
+
+	ackBody, _ := json.Marshal(AckRequest{
+		QueueId:       queueID,
+		ReceiptHandle: receiptHandle,
+		DeliveryToken: oldToken,
+	})
+	ackReq := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(ackBody))
+	ackRec := httptest.NewRecorder()
+	ack(ackRec, ackReq)
+	if ackRec.Code != http.StatusConflict {
+		t.Fatalf("stale token ack status = %d, want 409, body = %s", ackRec.Code, ackRec.Body.String())
+	}
+
+	ackBody2, _ := json.Marshal(AckRequest{
+		QueueId:       queueID,
+		ReceiptHandle: receiptHandle,
+		DeliveryToken: secondResp.DeliveryToken,
+	})
+	ackReq2 := httptest.NewRequest(http.MethodPost, "/ack", bytes.NewReader(ackBody2))
+	ackRec2 := httptest.NewRecorder()
+	ack(ackRec2, ackReq2)
+	if ackRec2.Code != http.StatusAccepted {
+		t.Fatalf("fresh token ack status = %d, want 202, body = %s", ackRec2.Code, ackRec2.Body.String())
+	}
+}
+
+func TestHandlerClaimWALFailureReturns500AndRollsBack(t *testing.T) {
+	wal := setupTestDBWithFakeWAL(t)
+	queueID := createTestQueue(t, "claim-wal-fail")
+
+	publishTestMessage(t, queueID, []byte("pending"))
+
+	wal.mu.Lock()
+	wal.fail = true
+	wal.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/receive?id="+queueID, nil)
+	rec := httptest.NewRecorder()
+	receive(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("receive during WAL failure: status = %d, want 500, body = %s", rec.Code, rec.Body.String())
+	}
+
+	ready, inflight, _ := runtimeQueueState(t, queueID)
+	if ready != 1 || inflight != 0 {
+		t.Fatalf("after WAL failure rollback: ready=%d inflight=%d, want 1,0", ready, inflight)
+	}
+
+	wal.mu.Lock()
+	wal.fail = false
+	wal.mu.Unlock()
+
+	resp := receiveTestMessage(t, queueID)
+	if resp.ID == "" {
+		t.Fatal("expected non-empty message id after successful receive post-rollback")
 	}
 }
 

--- a/reaper.go
+++ b/reaper.go
@@ -1,138 +1,13 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"time"
-
-	"github.com/cockroachdb/pebble/v2"
 )
 
 type reapTransition struct {
 	QueueID string
 	ToState MessageState
-}
-
-func reapExpiredMessages(now time.Time) ([]reapTransition, error) {
-	type expiredMsg struct {
-		indexKey []byte
-		msgKey   []byte
-	}
-	var expired []expiredMsg
-
-	prefix := inflightPrefix()
-	snap := Db.NewSnapshot()
-	defer snap.Close()
-	iter, _ := snap.NewIter(&pebble.IterOptions{
-		LowerBound: prefix,
-		UpperBound: prefixUpperBound(prefix),
-	})
-	defer iter.Close()
-
-	upper := inflightScanUpperBound(now)
-	for iter.SeekGE(prefix); iter.Valid(); iter.Next() {
-		key := append([]byte(nil), iter.Key()...)
-		if len(key) >= len(upper) && bytes.Compare(key[:len(upper)], upper) > 0 {
-			break
-		}
-
-		val, err := iter.ValueAndErr()
-		if err != nil {
-			return nil, err
-		}
-		expired = append(expired, expiredMsg{
-			indexKey: key,
-			msgKey:   append([]byte(nil), val...),
-		})
-	}
-
-	const reapBatch = 1024
-	transitions := make([]reapTransition, 0, len(expired))
-
-	for i := 0; i < len(expired); i += reapBatch {
-		end := i + reapBatch
-		if end > len(expired) {
-			end = len(expired)
-		}
-		chunk := expired[i:end]
-
-		batch := Db.NewIndexedBatch()
-		for _, exp := range chunk {
-			msgVal, closer, err := batch.Get(exp.msgKey)
-			if err != nil {
-				if err == pebble.ErrNotFound {
-					_ = batch.Delete(exp.indexKey, nil)
-					continue
-				}
-				batch.Close()
-				return transitions, err
-			}
-
-			var msg Message
-			if err := json.Unmarshal(msgVal, &msg); err != nil {
-				closer.Close()
-				batch.Close()
-				return transitions, err
-			}
-			closer.Close()
-
-			if msg.State != StateInFlight {
-				_ = batch.Delete(exp.indexKey, nil)
-				continue
-			}
-			if msg.VisibilityDeadline.IsZero() || now.Before(msg.VisibilityDeadline) {
-				_ = batch.Delete(exp.indexKey, nil)
-				continue
-			}
-
-			queueID, err := parseMessageKeyQueueID(exp.msgKey)
-			if err != nil {
-				batch.Close()
-				return transitions, err
-			}
-
-			if msg.MaxDeliveryCount > 0 && msg.DeliveryCount >= msg.MaxDeliveryCount {
-				msg.State = StateDead
-			} else {
-				msg.State = StateReady
-			}
-			msg.VisibilityDeadline = time.Time{}
-			msg.DeliveryAttemptID = ""
-
-			updated, err := json.Marshal(msg)
-			if err != nil {
-				batch.Close()
-				return transitions, err
-			}
-			if err := batch.Set(exp.msgKey, updated, nil); err != nil {
-				batch.Close()
-				return transitions, err
-			}
-			_ = batch.Delete(exp.indexKey, nil)
-
-			if msg.State == StateReady {
-				newSeq, err := nextMessageSequence(queueID)
-				if err != nil {
-					batch.Close()
-					return transitions, fmt.Errorf("allocate reaper sequence: %w", err)
-				}
-				if err := batch.Set(readyKey(queueID, newSeq, msg.ID), readyValue(exp.msgKey), nil); err != nil {
-					batch.Close()
-					return transitions, err
-				}
-			}
-
-			transitions = append(transitions, reapTransition{QueueID: queueID, ToState: msg.State})
-		}
-		if err := batch.Commit(pebble.NoSync); err != nil {
-			return transitions, err
-		}
-		batch.Close()
-	}
-
-	return transitions, nil
 }
 
 func reaper() {


### PR DESCRIPTION
Closes #30. Parent: #21. Depends on Phase 2.4 (PR #40, merged).

## Context

PR #40 (Phase 2.4) switched all handlers + reaper to `queueRuntime` + WAL to keep existing tests green. This absorbed #30's handler migration work. This PR completes #30 by fixing the benchmarks that broke when publish moved to the runtime, removing the now-dead legacy claim/reap code, and adding the handler-level validation tests #30 requires.

## Work

### Benchmark fixes

Four benchmarks were broken since PR #40 moved publish to the runtime, leaving Pebble keys empty. They used legacy `claimReadyMessages` / `reapExpiredMessages` which scan Pebble.

- **`BenchmarkBatchReceiveOnly`**, **`BenchmarkBatchAckOnly`**, **`BenchmarkBatchReceiveAndAck`**: replaced `claimReadyMessages` with `QueueManager.ClaimBatch` (runtime ready-list pop, same `[]claimedMessage` return type).
- **`BenchmarkReaperDueInflightIndex`**: replaced manual Pebble key manipulation + `reapExpiredMessages` with `QueueManager.ClaimBatch` (in-flight) + `QueueManager.ReapExpired` (force-reap with future timestamp). The runtime min-heap makes this O(n log n) instead of O(all keys).

### Dead code removal

- Removed `claimMu` (global `sync.Mutex`), `claimNextReadyMessage`, `claimReadyMessages` from `handlers_receive.go`. These serialized Pebble-based competing-consumer claims; the runtime uses per-queue mutexes instead.
- Removed `reapExpiredMessages` from `reaper.go`. The live reaper goroutine already uses `QueueManager.ReapExpired` since PR #40.
- Cleaned up now-unused imports (`bytes`, `encoding/json`, `fmt`, `pebble`, `sync`, `uuid` in `handlers_receive.go`; `bytes`, `encoding/json`, `fmt`, `pebble` in `reaper.go`).
- Removed `TestReapExpiredMessagesResetsPersistedInFlightMessage` (`t.Skip`'d, tested legacy Pebble reap path).

### New handler-level tests

1. **`TestCompetingConsumersNoDuplicateDelivery`** — 1 queue, 100 messages, 10 concurrent `receive` handler callers. Verifies zero duplicate IDs, all 100 consumed, no consumer starved (min > 0).
2. **`TestHandlerStaleAckTokenAfterRedeliveryReturns409`** — publish → receive → nack → re-receive → ack with old delivery token → **409 Conflict**. Confirms stale token rejection at the HTTP layer. Also verifies the fresh token ack succeeds (202).
3. **`TestHandlerClaimWALFailureReturns500AndRollsBack`** — publish → WAL failure → receive returns **500** → message remains in ready state → WAL recovered → receive succeeds. Confirms claim rollback on WAL failure at the handler level.

## Acceptance criteria (#30)

- [x] Single-consumer FIFO verification remains zero — `TestBatchReceiveFollowsFIFOOrder` passes.
- [x] Competing consumers cannot receive the same message — `TestCompetingConsumersNoDuplicateDelivery` verifies zero duplicates across 10 concurrent consumers.
- [x] Batch ack still returns per-entry results and does not fail the entire batch for invalid entries — `TestBatchAckReportsPartialErrors` passes.
- [x] Nack redelivery appends to ready tail, matching current behavior — `TestRuntimeReceiptHandlePreservedAcrossRedelivery` + `TestHandlerStaleAckTokenAfterRedeliveryReturns409` verify redelivery.
- [x] Stale ack/nack tokens return conflict — `TestHandlerStaleAckTokenAfterRedeliveryReturns409` asserts 409.
- [x] Receive/ack/nack no longer read or write old Pebble message keys — legacy `claimReadyMessages` and `reapExpiredMessages` removed.
- [x] Remove `claimMu` from the active receive path — deleted.

## Benchmark output

All 5 benchmarks pass. Comparison of the legacy Pebble hot path (`d149620`, pre-Phase-2.4) vs the runtime in-memory path (this branch):

| Benchmark | Legacy (ns/op) | Runtime (ns/op) | Speedup |
|-----------|---------------:|----------------:|--------:|
| ReceiveLatencyVsDepth/depth_100 | 176,000 | 22,933 | **7.7x** |
| ReceiveLatencyVsDepth/depth_1000 | 205,000 | 24,265 | **8.4x** |
| ReceiveLatencyVsDepth/depth_10000 | 2,807,000 | 26,052 | **108x** |
| BatchReceiveOnly/depth_100 | 2,316,000 | 37,383 | **62x** |
| BatchReceiveOnly/depth_1000 | 2,344,000 | 45,920 | **51x** |
| BatchReceiveOnly/depth_10000 | 2,382,000 | 44,731 | **53x** |
| BatchAckOnly/depth_100 | 334,000 | 87,161 | **3.8x** |
| BatchAckOnly/depth_1000 | — | 103,431 | — |
| BatchAckOnly/depth_10000 | — | 48,753 | — |
| BatchReceiveAndAck/depth_100 | — | 73,720 | — |
| BatchReceiveAndAck/depth_1000 | — | 64,725 | — |
| BatchReceiveAndAck/depth_10000 | — | 71,795 | — |
| ReaperDueInflightIndex/ready_100 | — | 1,965 | — |
| ReaperDueInflightIndex/ready_1000 | — | 1,850 | — |
| ReaperDueInflightIndex/ready_10000 | — | 2,094 | — |

Rows marked `—` were not captured for the legacy path (the benchmark run was aborted due to time — each legacy benchmark took 25+ minutes at `-benchtime=2s -count=3`). The runtime numbers are from `-benchtime=200ms -count=1`.

### Why it's faster

- **Receive latency: 7.7x–108x faster.** The legacy path did a Pebble iterator scan + JSON unmarshal + `IndexedBatch` commit per claim. The runtime pops the front of an in-memory linked list in O(1). At depth 10000, the iterator had to skip 10000 keys → 2.8ms vs 26us.
- **Batch receive: 51–62x faster.** Each legacy claim did a full `IndexedBatch` commit with ready-key delete, message-state rewrite, and inflight-index insert. The runtime does one WAL append for the whole batch and N linked-list pops.
- **Batch ack: 3.8x faster.** Ack still writes a WAL entry, but skips the Pebble iterator scan + index cleanup.
- **Reaper: ~2us** regardless of ready depth. The runtime uses a min-heap of deadlines, so reaping is O(n log n) on expired count only — it never touches ready messages or scans all keys.

### Runtime benchmark numbers (this branch)

```
BenchmarkReceiveLatencyVsDepth/depth_100-12          22933 ns/op
BenchmarkReceiveLatencyVsDepth/depth_1000-12         24265 ns/op
BenchmarkReceiveLatencyVsDepth/depth_10000-12        26052 ns/op
BenchmarkBatchReceiveOnly/depth_100-12               37383 ns/op
BenchmarkBatchReceiveOnly/depth_1000-12              45920 ns/op
BenchmarkBatchReceiveOnly/depth_10000-12             44731 ns/op
BenchmarkBatchAckOnly/depth_100-12                   87161 ns/op
BenchmarkBatchAckOnly/depth_1000-12                  103431 ns/op
BenchmarkBatchAckOnly/depth_10000-12                 48753 ns/op
BenchmarkBatchReceiveAndAck/depth_100-12             73720 ns/op
BenchmarkBatchReceiveAndAck/depth_1000-12            64725 ns/op
BenchmarkBatchReceiveAndAck/depth_10000-12           71795 ns/op
BenchmarkReaperDueInflightIndex/ready_depth_100-12   1965 ns/op
BenchmarkReaperDueInflightIndex/ready_depth_1000-12  1850 ns/op
BenchmarkReaperDueInflightIndex/ready_depth_10000-12 2094 ns/op
```

## Validation

```
go build ./...        # clean
go test ./...         # ok  kueue, ok kueue/cmd/bench
go test -race ./...   # ok  kueue, ok kueue/cmd/bench
go vet ./...          # clean
```

## Out of scope (deferred)

- Legacy Pebble key functions (`messageKey`, `readyKey`, `inflightKey`, `nextMessageSequence`, `messageByReceiptHandle`, `findMessageRecord`, key builders) and `store.go` functions remain in `keys.go`/`store.go`. Some are still referenced by metrics reconciliation tests (`TestReconcileMetricsFromDBIfStale*`) and `TestReadyPartsFromKeyUsesKnownPrefix`. Full removal is #35 (Phase 2.10).
- `/metrics` still runs `reconcileMetricsFromDB` over the now-empty Pebble keyspace. Moving metrics fully in-memory is #31 (Phase 2.6).
